### PR TITLE
feat(permissions): 实现前端三级权限控制与用户级权限覆盖

### DIFF
--- a/admin/src/router/index.ts
+++ b/admin/src/router/index.ts
@@ -33,6 +33,26 @@ const routes = [
         component: () => import('@/views/UsersView.vue')
       },
       {
+        path: 'roles',
+        name: 'Roles',
+        component: () => import('@/views/RolesView.vue')
+      },
+      {
+        path: 'roles/:id/permissions',
+        name: 'RolePermissions',
+        component: () => import('@/views/RolePermissionsView.vue')
+      },
+      {
+        path: 'users/:id/permissions',
+        name: 'UserPermissions',
+        component: () => import('@/views/UserPermissionsView.vue')
+      },
+      {
+        path: 'permissions',
+        name: 'Permissions',
+        component: () => import('@/views/PermissionsView.vue')
+      },
+      {
         path: 'quotes',
         name: 'Quotes',
         component: () => import('@/views/QuotesView.vue')

--- a/admin/src/services/roles.service.ts
+++ b/admin/src/services/roles.service.ts
@@ -1,0 +1,62 @@
+import { apiService } from './api'
+
+export interface FrontendRole {
+  id: number
+  code: string
+  name: string
+  description?: string
+  is_system: boolean
+  created_at: string
+}
+
+export interface PermissionTreeNode {
+  id: number
+  code: string
+  name: string
+  level: number
+  parent_code?: string | null
+  channel_code?: string | null
+  sort_order: number
+  children?: PermissionTreeNode[]
+}
+
+export class RolesService {
+  async listRoles(): Promise<FrontendRole[]> {
+    return apiService.get<FrontendRole[]>('/roles')
+  }
+
+  async createRole(data: { code: string; name: string; description?: string }): Promise<FrontendRole> {
+    return apiService.post<FrontendRole>('/roles', data)
+  }
+
+  async updateRole(id: number, data: { name?: string; description?: string }): Promise<FrontendRole> {
+    return apiService.put<FrontendRole>(`/roles/${id}`, data)
+  }
+
+  async deleteRole(id: number): Promise<{ success: boolean }> {
+    return apiService.delete<{ success: boolean }>(`/roles/${id}`)
+  }
+
+  async getRolePermissions(roleId: number): Promise<{ permission_codes: string[] }> {
+    return apiService.get<{ permission_codes: string[] }>(`/roles/${roleId}/permissions`)
+  }
+
+  async setRolePermissions(roleId: number, permissionCodes: string[]): Promise<{ success: boolean; count: number }> {
+    return apiService.put<{ success: boolean; count: number }>(`/roles/${roleId}/permissions`, {
+      permission_codes: permissionCodes
+    })
+  }
+}
+
+export class PermissionsService {
+  async getTree(): Promise<{ tree: PermissionTreeNode[] }> {
+    return apiService.get<{ tree: PermissionTreeNode[] }>('/permissions/tree')
+  }
+
+  async sync(): Promise<{ success: boolean; created: number; updated: number; total: number }> {
+    return apiService.post('/permissions/sync', {})
+  }
+}
+
+export const rolesService = new RolesService()
+export const permissionsService = new PermissionsService()

--- a/admin/src/services/users.service.ts
+++ b/admin/src/services/users.service.ts
@@ -59,6 +59,25 @@ export class UsersService {
   }> {
     return apiService.get('/users/stats')
   }
+
+  async getUserPermissions(userId: number): Promise<UserPermissionsDetail> {
+    return apiService.get<UserPermissionsDetail>(`/users/${userId}/permissions`)
+  }
+
+  async setUserPermissions(userId: number, permissionCodes: string[]): Promise<{ success: boolean; override_count: number }> {
+    return apiService.post(`/users/${userId}/permissions`, { permission_codes: permissionCodes })
+  }
+
+  async resetUserPermissions(userId: number): Promise<{ success: boolean; message: string }> {
+    return apiService.delete(`/users/${userId}/permissions`)
+  }
+}
+
+export interface UserPermissionsDetail {
+  role: { code: string; name: string }
+  role_permission_codes: string[]
+  effective_permission_codes: string[]
+  override_count: number
 }
 
 export const usersService = new UsersService()

--- a/admin/src/types/users.types.ts
+++ b/admin/src/types/users.types.ts
@@ -2,26 +2,29 @@ export interface User {
   id: number
   username: string
   email: string
-  role: 'admin' | 'user' | 'guest'
+  role: string
+  role_id?: number | null
   status: 'active' | 'disabled' | 'suspended'
   created_at: string
   updated_at?: string
   last_login?: string
-  wechat_userid?: string  // 企业微信成员UserID，用于微信通知
+  wechat_userid?: string
 }
 
 export interface CreateUserRequest {
   username: string
   email: string
   password: string
-  role: 'admin' | 'user' | 'guest'
+  role?: string
+  role_id?: number | null
 }
 
 export interface UpdateUserRequest {
   email?: string
-  role?: 'admin' | 'user' | 'guest'
+  role?: string
+  role_id?: number | null
   status?: 'active' | 'disabled' | 'suspended'
-  wechat_userid?: string  // 企业微信成员UserID，用于微信通知
+  wechat_userid?: string
 }
 
 export interface UsersResponse {

--- a/admin/src/views/AdminLayout.vue
+++ b/admin/src/views/AdminLayout.vue
@@ -70,7 +70,8 @@ import {
   Tickets,
   Select,
   Star,
-  Notebook
+  Notebook,
+  Lock
 } from '@element-plus/icons-vue'
 import { useAuthStore } from '@/stores/auth'
 
@@ -81,6 +82,8 @@ const authStore = useAuthStore()
 const menuItems = [
   { path: '/dashboard', name: '仪表板', icon: DataBoard },
   { path: '/users', name: '用户管理', icon: User },
+  { path: '/roles', name: '角色管理', icon: Lock },
+  { path: '/permissions', name: '权限资源', icon: Lock },
   { path: '/quotes', name: '行情数据', icon: TrendCharts },
   { path: '/stock-basic', name: '股票基本信息管理', icon: Tickets },
   { path: '/board-constituents', name: '板块成分股维护', icon: Histogram },

--- a/admin/src/views/PermissionsView.vue
+++ b/admin/src/views/PermissionsView.vue
@@ -1,0 +1,65 @@
+<template>
+  <div class="permissions-view">
+    <el-card>
+      <template #header>
+        <div class="card-header">
+          <span>权限资源浏览</span>
+          <el-button type="primary" :loading="syncing" @click="syncRegistry">从注册表同步</el-button>
+        </div>
+      </template>
+      <el-tree
+        :data="tree"
+        node-key="code"
+        default-expand-all
+        :props="{ label: renderLabel, children: 'children' }"
+      />
+    </el-card>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import { ElMessage } from 'element-plus'
+import { permissionsService, type PermissionTreeNode } from '@/services/roles.service'
+
+const tree = ref<PermissionTreeNode[]>([])
+const syncing = ref(false)
+
+function renderLabel(data: PermissionTreeNode) {
+  return `${data.name} (${data.code})`
+}
+
+async function loadTree() {
+  const resp = await permissionsService.getTree()
+  tree.value = resp.tree
+}
+
+async function syncRegistry() {
+  syncing.value = true
+  try {
+    const result = await permissionsService.sync()
+    ElMessage.success(`同步完成：新增 ${result.created}，更新 ${result.updated}`)
+    await loadTree()
+  } catch (e) {
+    ElMessage.error('同步失败')
+  } finally {
+    syncing.value = false
+  }
+}
+
+onMounted(async () => {
+  try {
+    await loadTree()
+  } catch {
+    ElMessage.error('加载权限树失败，请确认后端已重启并注册 /api/admin/permissions 路由')
+  }
+})
+</script>
+
+<style scoped>
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+</style>

--- a/admin/src/views/RolePermissionsView.vue
+++ b/admin/src/views/RolePermissionsView.vue
@@ -1,0 +1,86 @@
+<template>
+  <div class="role-permissions-view">
+    <el-card v-loading="loading">
+      <template #header>
+        <div class="card-header">
+          <span>角色权限配置：{{ roleName }}</span>
+          <div>
+            <el-button @click="$router.push('/roles')">返回</el-button>
+            <el-button type="primary" :loading="saving" @click="save">保存</el-button>
+          </div>
+        </div>
+      </template>
+      <p class="hint">每个频道/标签/按钮独立勾选，不联动父子节点。</p>
+      <el-tree
+        ref="treeRef"
+        :data="tree"
+        node-key="code"
+        show-checkbox
+        check-strictly
+        default-expand-all
+        :props="{ label: 'name', children: 'children' }"
+      />
+    </el-card>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref, nextTick } from 'vue'
+import { useRoute } from 'vue-router'
+import { ElMessage } from 'element-plus'
+import { rolesService, permissionsService, type PermissionTreeNode } from '@/services/roles.service'
+
+const route = useRoute()
+const roleId = Number(route.params.id)
+const roleName = ref('')
+const tree = ref<PermissionTreeNode[]>([])
+const loading = ref(false)
+const saving = ref(false)
+const treeRef = ref()
+
+async function load() {
+  loading.value = true
+  try {
+    const roles = await rolesService.listRoles()
+    roleName.value = roles.find(r => r.id === roleId)?.name || String(roleId)
+    const treeResp = await permissionsService.getTree()
+    tree.value = treeResp.tree
+    const permResp = await rolesService.getRolePermissions(roleId)
+    treeRef.value?.setCheckedKeys(permResp.permission_codes || [])
+    await nextTick()
+    treeRef.value?.setCheckedKeys(permResp.permission_codes || [])
+  } catch (e) {
+    ElMessage.error('加载权限树失败')
+  } finally {
+    loading.value = false
+  }
+}
+
+async function save() {
+  saving.value = true
+  try {
+    const codes = treeRef.value?.getCheckedKeys(false) as string[] || []
+    await rolesService.setRolePermissions(roleId, codes)
+    ElMessage.success('权限已保存')
+  } catch (e) {
+    ElMessage.error('保存失败')
+  } finally {
+    saving.value = false
+  }
+}
+
+onMounted(load)
+</script>
+
+<style scoped>
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.hint {
+  color: #666;
+  margin-bottom: 12px;
+  font-size: 13px;
+}
+</style>

--- a/admin/src/views/RolesView.vue
+++ b/admin/src/views/RolesView.vue
@@ -1,0 +1,121 @@
+<template>
+  <div class="roles-view">
+    <el-card>
+      <template #header>
+        <div class="card-header">
+          <span>角色管理</span>
+          <el-button type="primary" @click="openCreate">新建角色</el-button>
+        </div>
+      </template>
+      <el-table :data="roles" v-loading="loading" stripe>
+        <el-table-column prop="code" label="Code" width="140" />
+        <el-table-column prop="name" label="名称" width="160" />
+        <el-table-column prop="description" label="描述" min-width="200" />
+        <el-table-column label="系统内置" width="100">
+          <template #default="{ row }">
+            <el-tag :type="row.is_system ? 'info' : 'success'">{{ row.is_system ? '是' : '否' }}</el-tag>
+          </template>
+        </el-table-column>
+        <el-table-column label="操作" width="260" fixed="right">
+          <template #default="{ row }">
+            <el-button size="small" @click="goPermissions(row)">配置权限</el-button>
+            <el-button size="small" @click="openEdit(row)">编辑</el-button>
+            <el-button size="small" type="danger" :disabled="row.is_system" @click="removeRole(row)">删除</el-button>
+          </template>
+        </el-table-column>
+      </el-table>
+    </el-card>
+
+    <el-dialog v-model="dialogVisible" :title="editing ? '编辑角色' : '新建角色'" width="480px">
+      <el-form :model="form" label-width="80px">
+        <el-form-item label="Code" v-if="!editing">
+          <el-input v-model="form.code" placeholder="如 vip" />
+        </el-form-item>
+        <el-form-item label="名称">
+          <el-input v-model="form.name" />
+        </el-form-item>
+        <el-form-item label="描述">
+          <el-input v-model="form.description" type="textarea" />
+        </el-form-item>
+      </el-form>
+      <template #footer>
+        <el-button @click="dialogVisible = false">取消</el-button>
+        <el-button type="primary" @click="saveRole">保存</el-button>
+      </template>
+    </el-dialog>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { ElMessage, ElMessageBox } from 'element-plus'
+import { rolesService, type FrontendRole } from '@/services/roles.service'
+
+const router = useRouter()
+const roles = ref<FrontendRole[]>([])
+const loading = ref(false)
+const dialogVisible = ref(false)
+const editing = ref<FrontendRole | null>(null)
+const form = ref({ code: '', name: '', description: '' })
+
+async function loadRoles() {
+  loading.value = true
+  try {
+    roles.value = await rolesService.listRoles()
+  } catch (e) {
+    ElMessage.error('加载角色失败')
+  } finally {
+    loading.value = false
+  }
+}
+
+function openCreate() {
+  editing.value = null
+  form.value = { code: '', name: '', description: '' }
+  dialogVisible.value = true
+}
+
+function openEdit(row: FrontendRole) {
+  editing.value = row
+  form.value = { code: row.code, name: row.name, description: row.description || '' }
+  dialogVisible.value = true
+}
+
+async function saveRole() {
+  try {
+    if (editing.value) {
+      await rolesService.updateRole(editing.value.id, { name: form.value.name, description: form.value.description })
+      ElMessage.success('更新成功')
+    } else {
+      await rolesService.createRole(form.value)
+      ElMessage.success('创建成功')
+    }
+    dialogVisible.value = false
+    await loadRoles()
+  } catch (e) {
+    ElMessage.error('保存失败')
+  }
+}
+
+async function removeRole(row: FrontendRole) {
+  await ElMessageBox.confirm(`确定删除角色「${row.name}」？`, '提示', { type: 'warning' })
+  await rolesService.deleteRole(row.id)
+  ElMessage.success('已删除')
+  await loadRoles()
+}
+
+function goPermissions(row: FrontendRole) {
+  router.push(`/roles/${row.id}/permissions`)
+}
+
+onMounted(loadRoles)
+</script>
+
+<style scoped>
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+</style>

--- a/admin/src/views/UserPermissionsView.vue
+++ b/admin/src/views/UserPermissionsView.vue
@@ -1,0 +1,118 @@
+<template>
+  <div class="user-permissions-view">
+    <el-card v-loading="loading">
+      <template #header>
+        <div class="card-header">
+          <div>
+            <div class="title">用户权限：{{ username }}</div>
+            <div class="subtitle">
+              角色「{{ detail?.role?.name }}」默认 {{ detail?.role_permission_codes?.length || 0 }} 项；
+              当前生效 {{ detail?.effective_permission_codes?.length || 0 }} 项
+              <el-tag v-if="detail?.override_count" size="small" type="warning" style="margin-left:8px">
+                个性化 {{ detail?.override_count }} 项
+              </el-tag>
+            </div>
+          </div>
+          <div>
+            <el-button @click="$router.push('/users')">返回</el-button>
+            <el-button :disabled="!detail?.override_count" @click="resetToRole">恢复角色默认</el-button>
+            <el-button type="primary" :loading="saving" @click="save">保存</el-button>
+          </div>
+        </div>
+      </template>
+      <p class="hint">
+        勾选为用户<strong>最终生效</strong>的权限。同一角色下，不同用户可单独配置（例如 A 可见选股、B 不可见）。
+        与角色默认一致时不会写入个性化覆盖。
+      </p>
+      <el-tree
+        ref="treeRef"
+        :data="tree"
+        node-key="code"
+        show-checkbox
+        check-strictly
+        default-expand-all
+        :props="{ label: renderLabel, children: 'children' }"
+      />
+    </el-card>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref, nextTick } from 'vue'
+import { useRoute } from 'vue-router'
+import { ElMessage, ElMessageBox } from 'element-plus'
+import { permissionsService, type PermissionTreeNode } from '@/services/roles.service'
+import { usersService, type UserPermissionsDetail } from '@/services/users.service'
+
+const route = useRoute()
+const userId = Number(route.params.id)
+const username = ref(String(route.query.username || userId))
+const tree = ref<PermissionTreeNode[]>([])
+const detail = ref<UserPermissionsDetail | null>(null)
+const loading = ref(false)
+const saving = ref(false)
+const treeRef = ref()
+
+function renderLabel(data: PermissionTreeNode) {
+  const inRole = detail.value?.role_permission_codes?.includes(data.code)
+  return `${data.name}${inRole ? '' : ' (角色无)'}`
+}
+
+async function load() {
+  loading.value = true
+  try {
+    const [treeResp, permResp] = await Promise.all([
+      permissionsService.getTree(),
+      usersService.getUserPermissions(userId)
+    ])
+    tree.value = treeResp.tree
+    detail.value = permResp
+    await nextTick()
+    treeRef.value?.setCheckedKeys(permResp.effective_permission_codes || [])
+  } catch (e) {
+    ElMessage.error('加载用户权限失败')
+  } finally {
+    loading.value = false
+  }
+}
+
+async function save() {
+  saving.value = true
+  try {
+    const codes = treeRef.value?.getCheckedKeys(false) as string[] || []
+    const result = await usersService.setUserPermissions(userId, codes)
+    ElMessage.success(`已保存，个性化覆盖 ${result.override_count} 项`)
+    await load()
+  } catch (e) {
+    ElMessage.error('保存失败')
+  } finally {
+    saving.value = false
+  }
+}
+
+async function resetToRole() {
+  await ElMessageBox.confirm('确定恢复为角色默认权限？将清除该用户所有个性化设置。', '提示', { type: 'warning' })
+  await usersService.resetUserPermissions(userId)
+  ElMessage.success('已恢复角色默认权限')
+  await load()
+}
+
+onMounted(load)
+</script>
+
+<style scoped>
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+}
+.title { font-weight: 600; font-size: 16px; }
+.subtitle { font-size: 13px; color: #666; margin-top: 4px; }
+.hint {
+  color: #666;
+  margin-bottom: 12px;
+  font-size: 13px;
+  line-height: 1.6;
+}
+</style>

--- a/admin/src/views/UsersView.vue
+++ b/admin/src/views/UsersView.vue
@@ -95,9 +95,7 @@
             style="width: 100%"
           >
             <el-option label="全部" value="" />
-            <el-option label="管理员" value="admin" />
-            <el-option label="用户" value="user" />
-            <el-option label="访客" value="guest" />
+            <el-option v-for="r in frontendRoles" :key="r.id" :label="r.name" :value="r.code" />
           </el-select>
         </el-col>
         <el-col :xs="24" :sm="24" :md="8" :lg="8" :xl="8">
@@ -134,7 +132,7 @@
               :type="getRoleTagType(row.role)"
               size="small"
             >
-              {{ getRoleText(row.role) }}
+              {{ getRoleText(row.role, row.role_id) }}
             </el-tag>
           </template>
         </el-table-column>
@@ -177,6 +175,7 @@
               </el-button>
               <template #dropdown>
                 <el-dropdown-menu>
+                  <el-dropdown-item command="permissions">配置权限</el-dropdown-item>
                   <el-dropdown-item command="change_password">修改密码</el-dropdown-item>
                   <el-dropdown-item command="reset_password">初始化密码</el-dropdown-item>
                   <el-dropdown-item
@@ -248,11 +247,9 @@
             show-password
           />
         </el-form-item>
-        <el-form-item label="角色" prop="role">
-          <el-select v-model="createForm.role" placeholder="选择用户角色">
-            <el-option label="用户" value="user" />
-            <el-option label="管理员" value="admin" />
-            <el-option label="访客" value="guest" />
+        <el-form-item label="角色" prop="role_id">
+          <el-select v-model="createForm.role_id" placeholder="选择用户角色">
+            <el-option v-for="r in frontendRoles" :key="r.id" :label="r.name" :value="r.id" />
           </el-select>
         </el-form-item>
       </el-form>
@@ -283,11 +280,9 @@
         <el-form-item label="邮箱" prop="email">
           <el-input v-model="editForm.email" placeholder="请输入邮箱地址" />
         </el-form-item>
-        <el-form-item label="角色" prop="role">
-          <el-select v-model="editForm.role" placeholder="选择用户角色">
-            <el-option label="用户" value="user" />
-            <el-option label="管理员" value="admin" />
-            <el-option label="访客" value="guest" />
+        <el-form-item label="角色" prop="role_id">
+          <el-select v-model="editForm.role_id" placeholder="选择用户角色">
+            <el-option v-for="r in frontendRoles" :key="r.id" :label="r.name" :value="r.id" />
           </el-select>
         </el-form-item>
         <el-form-item label="状态" prop="status">
@@ -332,7 +327,8 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, computed, onUnmounted } from 'vue'
+import { ref, onMounted, onUnmounted, computed } from 'vue'
+import { useRouter } from 'vue-router'
 import { ElMessageBox } from 'element-plus'
 import {
   Plus,
@@ -345,10 +341,12 @@ import {
   ArrowDown
 } from '@element-plus/icons-vue'
 import { useUsersStore } from '@/stores/users'
+import { rolesService, type FrontendRole } from '@/services/roles.service'
 import type { User as UserType, CreateUserRequest, UpdateUserRequest } from '@/types/users.types'
 import type { FormInstance, FormRules } from 'element-plus'
 
 const usersStore = useUsersStore()
+const router = useRouter()
 
 // Refs
 const createFormRef = ref<FormInstance>()
@@ -362,6 +360,7 @@ const changePasswordForm = ref<{ userId: number | null; password: string }>({ us
 const searchKeyword = ref('')
 const statusFilter = ref('')
 const roleFilter = ref('')
+const frontendRoles = ref<FrontendRole[]>([])
 const currentEditUser = ref<UserType | null>(null)
 const tableHeight = ref(720) // 表格默认高度（约 15 行），实际由 updateTableHeight 按窗口与最小高度取大
 
@@ -370,13 +369,13 @@ const createForm = ref<CreateUserRequest>({
   username: '',
   email: '',
   password: '',
-  role: 'user'
+  role_id: undefined
 })
 
 const editForm = ref<UpdateUserRequest & { username: string }>({
   username: '',
   email: '',
-  role: 'user',
+  role_id: undefined,
   status: 'active',
   wechat_userid: ''
 })
@@ -395,7 +394,7 @@ const createRules: FormRules = {
     { required: true, message: '请输入密码', trigger: 'blur' },
     { min: 6, message: '密码长度不能少于6位', trigger: 'blur' }
   ],
-  role: [
+  role_id: [
     { required: true, message: '请选择用户角色', trigger: 'change' }
   ]
 }
@@ -405,7 +404,7 @@ const editRules: FormRules = {
     { required: true, message: '请输入邮箱地址', trigger: 'blur' },
     { type: 'email', message: '请输入正确的邮箱地址', trigger: 'blur' }
   ],
-  role: [
+  role_id: [
     { required: true, message: '请选择用户角色', trigger: 'change' }
   ],
   status: [
@@ -455,13 +454,18 @@ const formatDate = (dateStr: string) => {
   return new Date(dateStr).toLocaleString()
 }
 
-const getRoleText = (role: string) => {
-  const roleMap = {
-    admin: '管理员',
-    user: '用户',
+const getRoleText = (role: string, roleId?: number | null) => {
+  if (roleId != null) {
+    const found = frontendRoles.value.find(r => r.id === roleId)
+    if (found) return found.name
+  }
+  const roleMap: Record<string, string> = {
+    admin: '前台管理员',
+    standard: '标准用户',
+    user: '标准用户',
     guest: '访客'
   }
-  return roleMap[role as keyof typeof roleMap] || role
+  return roleMap[role] || role
 }
 
 const getRoleTagType = (role: string): 'success' | 'primary' | 'warning' | 'info' | 'danger' => {
@@ -519,11 +523,12 @@ const handleCurrentChange = (page: number) => {
 }
 
 const resetCreateForm = () => {
+  const defaultRole = frontendRoles.value.find(r => r.code === 'standard')
   createForm.value = {
     username: '',
     email: '',
     password: '',
-    role: 'user'
+    role_id: defaultRole?.id
   }
   createFormRef.value?.resetFields()
 }
@@ -532,7 +537,7 @@ const resetEditForm = () => {
   editForm.value = {
     username: '',
     email: '',
-    role: 'user',
+    role_id: undefined,
     status: 'active',
     wechat_userid: ''
   }
@@ -558,7 +563,7 @@ const editUser = (user: UserType) => {
   editForm.value = {
     username: user.username,
     email: user.email,
-    role: user.role,
+    role_id: user.role_id ?? frontendRoles.value.find(r => r.code === user.role)?.id,
     status: user.status,
     wechat_userid: user.wechat_userid ?? ''
   }
@@ -582,6 +587,9 @@ const handleUpdateUser = async () => {
 const handleUserAction = async (action: string, user: UserType) => {
   try {
     switch (action) {
+      case 'permissions':
+        router.push({ path: `/users/${user.id}/permissions`, query: { username: user.username } })
+        break
       case 'change_password':
         changePasswordForm.value = { userId: user.id, password: '' }
         showChangePasswordDialog.value = true
@@ -631,31 +639,30 @@ const submitChangePassword = async () => {
   changePasswordForm.value = { userId: null, password: '' }
 }
 
-// Lifecycle
-onMounted(async () => {
-  console.log('🚀 用户管理页面已挂载，开始加载数据...')
-  
-  // 设置响应式表格高度：保证至少可显示约 15 条记录（约 600px），再按窗口剩余空间放大
+const updateTableHeight = () => {
   const ROW_HEIGHT_ESTIMATE = 48
   const MIN_VISIBLE_ROWS = 15
   const MIN_TABLE_HEIGHT = Math.max(400, ROW_HEIGHT_ESTIMATE * MIN_VISIBLE_ROWS)
+  const windowHeight = window.innerHeight
+  const headerHeight = 64
+  const statsHeight = 120
+  const searchHeight = 100
+  const paginationHeight = 72
+  const padding = 48
+  const calculated = windowHeight - headerHeight - statsHeight - searchHeight - paginationHeight - padding
+  tableHeight.value = Math.max(MIN_TABLE_HEIGHT, calculated)
+}
 
-  const updateTableHeight = () => {
-    const windowHeight = window.innerHeight
-    const headerHeight = 64
-    const statsHeight = 120
-    const searchHeight = 100
-    const paginationHeight = 72
-    const padding = 48
-
-    const calculated = windowHeight - headerHeight - statsHeight - searchHeight - paginationHeight - padding
-    tableHeight.value = Math.max(MIN_TABLE_HEIGHT, calculated)
+// Lifecycle
+onMounted(async () => {
+  console.log('🚀 用户管理页面已挂载，开始加载数据...')
+  try {
+    frontendRoles.value = await rolesService.listRoles()
+  } catch (e) {
+    console.error('加载角色列表失败', e)
   }
-  
-  // 初始设置
+
   updateTableHeight()
-  
-  // 监听窗口大小变化
   window.addEventListener('resize', updateTableHeight)
   
   try {
@@ -668,11 +675,10 @@ onMounted(async () => {
   } catch (error) {
     console.error('❌ 用户数据加载失败:', error)
   }
-  
-  // 清理事件监听器
-  onUnmounted(() => {
-    window.removeEventListener('resize', updateTableHeight)
-  })
+})
+
+onUnmounted(() => {
+  window.removeEventListener('resize', updateTableHeight)
 })
 </script> 
 

--- a/admin/vite.config.ts
+++ b/admin/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import fs from 'node:fs'
 import path from 'node:path'
@@ -73,51 +73,54 @@ function vitePluginServeFrontendStatic(): Plugin {
   }
 }
 
-/** 本地 dev / preview 时将 /api 转到后端，与前端相对路径 /api/admin 配合 */
-const apiDevProxy = {
-  '/api': {
-    target: 'http://localhost:5000',
-    changeOrigin: true,
-    secure: false,
-  },
-} as const
-
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [vue(), vitePluginServeFrontendStatic()],
-  resolve: {
-    alias: {
-      '@': resolve(__dirname, 'src'),
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, path.resolve(__dirname, '..'), '')
+  const backendPort = env.BACKEND_PORT || env.VITE_BACKEND_PORT || '5000'
+  const apiDevProxy = {
+    '/api': {
+      target: `http://localhost:${backendPort}`,
+      changeOrigin: true,
+      secure: false,
     },
-  },
-  // 添加基础路径配置，支持生产环境部署
-  base: process.env.NODE_ENV === 'production' ? '/admin/' : '/',
-  server: {
-    port: 8001,
-    host: true,
-    proxy: apiDevProxy,
-  },
-  // 新增：生产预览端口配置
-  preview: {
-    port: 8001,
-    host: true,
-    proxy: apiDevProxy,
-  },
-  build: {
-    outDir: 'dist',
-    sourcemap: false, // 生产环境关闭sourcemap
-    // 确保资源路径正确
-    assetsDir: 'assets',
-    rollupOptions: {
-      output: {
-        manualChunks: {
-          vendor: ['vue', 'vue-router', 'pinia'],
-          elementPlus: ['element-plus'],
+  } as const
+
+  return {
+    plugins: [vue(), vitePluginServeFrontendStatic()],
+    resolve: {
+      alias: {
+        '@': resolve(__dirname, 'src'),
+      },
+    },
+    // 添加基础路径配置，支持生产环境部署
+    base: process.env.NODE_ENV === 'production' ? '/admin/' : '/',
+    server: {
+      port: 8001,
+      host: true,
+      proxy: apiDevProxy,
+    },
+    // 新增：生产预览端口配置
+    preview: {
+      port: 8001,
+      host: true,
+      proxy: apiDevProxy,
+    },
+    build: {
+      outDir: 'dist',
+      sourcemap: false, // 生产环境关闭sourcemap
+      // 确保资源路径正确
+      assetsDir: 'assets',
+      rollupOptions: {
+        output: {
+          manualChunks: {
+            vendor: ['vue', 'vue-router', 'pinia'],
+            elementPlus: ['element-plus'],
+          },
         },
       },
     },
-  },
-  css: {
-    postcss: './postcss.config.cjs',
-  },
-}) 
+    css: {
+      postcss: './postcss.config.cjs',
+    },
+  }
+})

--- a/backend_api/admin/permissions.py
+++ b/backend_api/admin/permissions.py
@@ -1,0 +1,43 @@
+"""
+管理端 - 前端权限资源管理
+"""
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from backend_api.auth import get_current_admin
+from backend_api.database import get_db
+from backend_api.models import FrontendPermissionInDB, FrontendPermission
+from backend_api.permissions import build_permission_tree, sync_permissions_from_registry
+
+router = APIRouter(prefix="/api/admin/permissions", tags=["admin-permissions"])
+
+
+@router.get("/tree")
+async def get_permissions_tree(
+    current_admin=Depends(get_current_admin),
+    db: Session = Depends(get_db),
+):
+    return {"tree": build_permission_tree(db)}
+
+
+@router.get("", response_model=list[FrontendPermissionInDB])
+async def list_permissions(
+    current_admin=Depends(get_current_admin),
+    db: Session = Depends(get_db),
+):
+    return (
+        db.query(FrontendPermission)
+        .filter(FrontendPermission.is_active.is_(True))
+        .order_by(FrontendPermission.sort_order, FrontendPermission.code)
+        .all()
+    )
+
+
+@router.post("/sync")
+async def sync_permissions(
+    current_admin=Depends(get_current_admin),
+    db: Session = Depends(get_db),
+):
+    result = sync_permissions_from_registry(db)
+    return {"success": True, **result}

--- a/backend_api/admin/roles.py
+++ b/backend_api/admin/roles.py
@@ -1,0 +1,115 @@
+"""
+管理端 - 前端角色管理
+"""
+
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from backend_api.auth import get_current_admin
+from backend_api.database import get_db
+from backend_api.models import (
+    FrontendRole,
+    FrontendRoleCreate,
+    FrontendRoleUpdate,
+    FrontendRoleInDB,
+    RolePermissionsUpdate,
+)
+from backend_api.permissions import get_role_permission_codes, sync_permissions_from_registry
+
+router = APIRouter(prefix="/api/admin/roles", tags=["admin-roles"])
+
+
+@router.get("", response_model=List[FrontendRoleInDB])
+async def list_roles(
+    current_admin=Depends(get_current_admin),
+    db: Session = Depends(get_db),
+):
+    return db.query(FrontendRole).order_by(FrontendRole.id).all()
+
+
+@router.post("", response_model=FrontendRoleInDB, status_code=status.HTTP_201_CREATED)
+async def create_role(
+    payload: FrontendRoleCreate,
+    current_admin=Depends(get_current_admin),
+    db: Session = Depends(get_db),
+):
+    exists = db.query(FrontendRole).filter(FrontendRole.code == payload.code).first()
+    if exists:
+        raise HTTPException(status_code=400, detail="角色 code 已存在")
+    role = FrontendRole(**payload.dict())
+    db.add(role)
+    db.commit()
+    db.refresh(role)
+    return role
+
+
+@router.put("/{role_id}", response_model=FrontendRoleInDB)
+async def update_role(
+    role_id: int,
+    payload: FrontendRoleUpdate,
+    current_admin=Depends(get_current_admin),
+    db: Session = Depends(get_db),
+):
+    role = db.query(FrontendRole).filter(FrontendRole.id == role_id).first()
+    if not role:
+        raise HTTPException(status_code=404, detail="角色不存在")
+    for field, value in payload.dict(exclude_unset=True).items():
+        setattr(role, field, value)
+    db.commit()
+    db.refresh(role)
+    return role
+
+
+@router.delete("/{role_id}")
+async def delete_role(
+    role_id: int,
+    current_admin=Depends(get_current_admin),
+    db: Session = Depends(get_db),
+):
+    role = db.query(FrontendRole).filter(FrontendRole.id == role_id).first()
+    if not role:
+        raise HTTPException(status_code=404, detail="角色不存在")
+    if role.is_system:
+        raise HTTPException(status_code=400, detail="系统内置角色不可删除")
+    db.delete(role)
+    db.commit()
+    return {"success": True}
+
+
+@router.get("/{role_id}/permissions")
+async def get_role_permissions(
+    role_id: int,
+    current_admin=Depends(get_current_admin),
+    db: Session = Depends(get_db),
+):
+    role = db.query(FrontendRole).filter(FrontendRole.id == role_id).first()
+    if not role:
+        raise HTTPException(status_code=404, detail="角色不存在")
+    return {"permission_codes": get_role_permission_codes(db, role)}
+
+
+@router.put("/{role_id}/permissions")
+async def set_role_permissions(
+    role_id: int,
+    payload: RolePermissionsUpdate,
+    current_admin=Depends(get_current_admin),
+    db: Session = Depends(get_db),
+):
+    from backend_api.models import FrontendPermission
+
+    role = db.query(FrontendRole).filter(FrontendRole.id == role_id).first()
+    if not role:
+        raise HTTPException(status_code=404, detail="角色不存在")
+    perms = (
+        db.query(FrontendPermission)
+        .filter(
+            FrontendPermission.code.in_(payload.permission_codes),
+            FrontendPermission.is_active.is_(True),
+        )
+        .all()
+    )
+    role.permissions = perms
+    db.commit()
+    return {"success": True, "count": len(perms)}

--- a/backend_api/admin/user_permissions.py
+++ b/backend_api/admin/user_permissions.py
@@ -1,0 +1,57 @@
+"""
+管理端 - 用户级权限覆盖（独立路由模块，与 users.py 解耦便于部署识别）
+"""
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from backend_api.auth import get_current_admin
+from backend_api.database import get_db
+from backend_api.models import User, UserPermissionsUpdate, UserPermissionsDetail
+from backend_api.permissions import (
+    build_user_permissions_detail,
+    set_user_effective_permissions,
+    clear_user_permission_overrides,
+)
+
+router = APIRouter(prefix="/api/admin/users", tags=["admin-user-permissions"])
+
+
+@router.get("/{user_id}/permissions", response_model=UserPermissionsDetail)
+async def get_user_permissions(
+    user_id: int,
+    current_admin=Depends(get_current_admin),
+    db: Session = Depends(get_db),
+):
+    db_user = db.query(User).filter(User.id == user_id).first()
+    if not db_user:
+        raise HTTPException(status_code=404, detail="用户不存在")
+    return build_user_permissions_detail(db, db_user)
+
+
+@router.put("/{user_id}/permissions")
+@router.post("/{user_id}/permissions")
+async def set_user_permissions(
+    user_id: int,
+    payload: UserPermissionsUpdate,
+    current_admin=Depends(get_current_admin),
+    db: Session = Depends(get_db),
+):
+    db_user = db.query(User).filter(User.id == user_id).first()
+    if not db_user:
+        raise HTTPException(status_code=404, detail="用户不存在")
+    override_count = set_user_effective_permissions(db, db_user, payload.permission_codes)
+    return {"success": True, "override_count": override_count}
+
+
+@router.delete("/{user_id}/permissions")
+async def reset_user_permissions(
+    user_id: int,
+    current_admin=Depends(get_current_admin),
+    db: Session = Depends(get_db),
+):
+    db_user = db.query(User).filter(User.id == user_id).first()
+    if not db_user:
+        raise HTTPException(status_code=404, detail="用户不存在")
+    clear_user_permission_overrides(db, user_id)
+    return {"success": True, "message": "已恢复为角色默认权限"}

--- a/backend_api/admin/users.py
+++ b/backend_api/admin/users.py
@@ -8,11 +8,9 @@ from sqlalchemy.orm import Session
 from sqlalchemy import desc, or_
 from pydantic import BaseModel
 
-from backend_api.models import UserCreate, UserUpdate, UserInDB
+from backend_api.models import UserCreate, UserUpdate, UserInDB, FrontendRole, User
 from backend_api.database import get_db
-from backend_api.auth import get_password_hash
-from backend_api.auth import get_current_admin
-from backend_api.models import User
+from backend_api.auth import get_password_hash, get_current_admin
 
 router = APIRouter(prefix="/api/admin/users", tags=["admin"])
 
@@ -93,11 +91,21 @@ async def create_user(
             )
         
         # 创建新用户
+        role_id = user.role_id
+        if role_id is None and user.role:
+            role_obj = db.query(FrontendRole).filter(FrontendRole.code == user.role).first()
+            if role_obj:
+                role_id = role_obj.id
+            else:
+                standard = db.query(FrontendRole).filter(FrontendRole.code == "standard").first()
+                role_id = standard.id if standard else None
+
         db_user = User(
             username=user.username,
             email=user.email,
             password_hash=get_password_hash(user.password),
-            role=user.role,
+            role=user.role or "user",
+            role_id=role_id,
             status="active"
         )
         db.add(db_user)
@@ -126,8 +134,64 @@ def _update_user_impl(user_id: int, user_update: UserUpdate, db: Session) -> Use
             detail="用户不存在"
         )
     update_data = user_update.dict(exclude_unset=True)
+    if "role_id" in update_data and update_data["role_id"] is not None:
+        role_obj = db.query(FrontendRole).filter(FrontendRole.id == update_data["role_id"]).first()
+        if role_obj:
+            update_data["role"] = role_obj.code
     for field, value in update_data.items():
         setattr(db_user, field, value)
+    db.commit()
+    db.refresh(db_user)
+    return db_user
+
+
+@router.get("/stats")
+async def get_user_stats(
+    current_user = Depends(get_current_admin),
+    db: Session = Depends(get_db)
+):
+    """获取用户统计信息"""
+    total = db.query(User).count()
+    active = db.query(User).filter(User.status == "active").count()
+    disabled = db.query(User).filter(User.status == "disabled").count()
+    suspended = db.query(User).filter(User.status == "suspended").count()
+    
+    return {
+        "total": total,
+        "active": active,
+        "disabled": disabled,
+        "suspended": suspended
+    }
+
+
+@router.get("/test")
+async def test_users_api():
+    """测试用户API是否正常工作"""
+    return {
+        "message": "Users API is working",
+        "timestamp": "2024-01-01T00:00:00"
+    }
+
+
+class UserRoleUpdate(BaseModel):
+    role_id: int
+
+
+@router.put("/{user_id}/role", response_model=UserInDB)
+async def update_user_role(
+    user_id: int,
+    payload: UserRoleUpdate,
+    current_user=Depends(get_current_admin),
+    db: Session = Depends(get_db),
+):
+    db_user = db.query(User).filter(User.id == user_id).first()
+    if not db_user:
+        raise HTTPException(status_code=404, detail="用户不存在")
+    role_obj = db.query(FrontendRole).filter(FrontendRole.id == payload.role_id).first()
+    if not role_obj:
+        raise HTTPException(status_code=404, detail="角色不存在")
+    db_user.role_id = role_obj.id
+    db_user.role = role_obj.code
     db.commit()
     db.refresh(db_user)
     return db_user
@@ -137,8 +201,8 @@ def _update_user_impl(user_id: int, user_update: UserUpdate, db: Session) -> Use
 async def update_user_put(
     user_id: int,
     user_update: UserUpdate,
-    current_user = Depends(get_current_admin),
-    db: Session = Depends(get_db)
+    current_user=Depends(get_current_admin),
+    db: Session = Depends(get_db),
 ):
     """更新用户信息（PUT）。"""
     return _update_user_impl(user_id, user_update, db)
@@ -148,10 +212,10 @@ async def update_user_put(
 async def update_user_post(
     user_id: int,
     user_update: UserUpdate,
-    current_user = Depends(get_current_admin),
-    db: Session = Depends(get_db)
+    current_user=Depends(get_current_admin),
+    db: Session = Depends(get_db),
 ):
-    """更新用户信息（POST）；与 PUT 行为一致，用于生产环境对 PUT 有限制时。"""
+    """更新用户信息（POST）；与 PUT 行为一致。"""
     return _update_user_impl(user_id, user_update, db)
 
 
@@ -262,43 +326,3 @@ async def reset_user_password(
     db.commit()
 
     return {"message": "密码已重置为默认值", "default": DEFAULT_PASSWORD}
-
-@router.get("/stats")
-async def get_user_stats(
-    current_user = Depends(get_current_admin),
-    db: Session = Depends(get_db)
-):
-    """获取用户统计信息"""
-    total = db.query(User).count()
-    active = db.query(User).filter(User.status == "active").count()
-    disabled = db.query(User).filter(User.status == "disabled").count()
-    suspended = db.query(User).filter(User.status == "suspended").count()
-    
-    return {
-        "total": total,
-        "active": active,
-        "disabled": disabled,
-        "suspended": suspended
-    }
-
-@router.get("/test")
-async def test_users_api():
-    """测试用户API是否正常工作"""
-    return {
-        "message": "用户管理API正常工作",
-        "timestamp": "2024-01-01T00:00:00Z",
-        "data": [
-            {
-                "id": 1,
-                "username": "test_user",
-                "email": "test@example.com",
-                "role": "user",
-                "status": "active",
-                "created_at": "2024-01-01T00:00:00Z",
-                "updated_at": "2024-01-01T00:00:00Z"
-            }
-        ],
-        "total": 1,
-        "page": 1,
-        "pageSize": 20
-    } 

--- a/backend_api/auth.py
+++ b/backend_api/auth.py
@@ -29,6 +29,7 @@ pwd_context = CryptContext(
 
 # OAuth2 scheme
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="api/auth/login")
+oauth2_scheme_optional = OAuth2PasswordBearer(tokenUrl="api/auth/login", auto_error=False)
 
 # JWT配置
 SECRET_KEY = JWT_CONFIG["secret_key"]
@@ -155,6 +156,19 @@ async def get_current_user(token: str = Depends(oauth2_scheme), db: Session = De
     if user is None:
         raise credentials_exception
     return user
+
+
+async def get_current_user_optional(
+    token: Optional[str] = Depends(oauth2_scheme_optional),
+    db: Session = Depends(get_db),
+) -> Optional[User]:
+    """获取当前用户（可选，无 token 时返回 None）"""
+    if not token:
+        return None
+    try:
+        return await get_current_user(token, db)
+    except HTTPException:
+        return None
 
 async def get_current_admin(token: str = Depends(oauth2_scheme), db: Session = Depends(get_db)) -> Admin:
     """获取当前管理员"""

--- a/backend_api/auth_routes.py
+++ b/backend_api/auth_routes.py
@@ -21,8 +21,10 @@ from .auth import (
     authenticate_user,
     create_access_token,
     get_current_user,
+    get_current_user_optional,
     ACCESS_TOKEN_EXPIRE_MINUTES
 )
+from .permissions import build_permissions_response
 
 # 配置日志（.env 中 LOG_TO_FILE=true 时才写文件）
 from backend_core.logging_utils import should_log_to_file
@@ -95,29 +97,10 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
 
 router = APIRouter(prefix="/api/auth", tags=["auth"])
 
-# OAuth2 scheme
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="api/auth/login", auto_error=False)
-
 class LoginRequest(BaseModel):
     """登录请求数据模型"""
     username: str
     password: str
-
-async def get_current_user_optional(
-    token: Optional[str] = Depends(oauth2_scheme),
-    db: Session = Depends(get_db)
-) -> Optional[User]:
-    """获取当前用户（可选）"""
-    if not token:
-        logger.debug("未提供认证令牌")
-        return None
-    try:
-        user = await get_current_user(token, db)
-        logger.debug(f"成功获取当前用户: {user.username} (ID: {user.id})")
-        return user
-    except Exception as e:
-        logger.warning(f"获取当前用户失败: {str(e)}")
-        return None
 
 @router.post("/login", response_model=Token)
 async def login(
@@ -209,6 +192,9 @@ async def login(
                 "token_type": "bearer",
                 "user": UserInDB.from_orm(user)
             }
+            perm_resp = build_permissions_response(db, user)
+            response["permissions"] = perm_resp.permissions
+            response["role"] = perm_resp.role
             
             # 计算总处理时间
             process_time = time.time() - start_time
@@ -249,7 +235,8 @@ async def login(
 @router.get("/status")
 async def get_auth_status(
     request: Request,
-    current_user: Optional[User] = Depends(get_current_user_optional)
+    current_user: Optional[User] = Depends(get_current_user_optional),
+    db: Session = Depends(get_db),
 ):
     """获取认证状态"""
     start_time = time.time()
@@ -259,6 +246,7 @@ async def get_auth_status(
     try:
         if current_user:
             process_time = time.time() - start_time
+            perm_resp = build_permissions_response(db, current_user)
             logger.info(
                 f"获取认证状态: 用户已登录 - "
                 f"用户: {current_user.username}, "
@@ -270,10 +258,13 @@ async def get_auth_status(
             return {
                 "success": True,
                 "logged_in": True,
-                "user": UserInDB.from_orm(current_user)
+                "user": UserInDB.from_orm(current_user),
+                "permissions": perm_resp.permissions,
+                "role": perm_resp.role,
             }
         else:
             process_time = time.time() - start_time
+            perm_resp = build_permissions_response(db, None)
             logger.info(
                 f"获取认证状态: 用户未登录 - "
                 f"IP: {client_host}, "
@@ -283,7 +274,9 @@ async def get_auth_status(
             return {
                 "success": True,
                 "logged_in": False,
-                "user": None
+                "user": None,
+                "permissions": perm_resp.permissions,
+                "role": perm_resp.role,
             }
     except Exception as e:
         error_detail = f"获取认证状态时发生错误: {str(e)}\n{traceback.format_exc()}"
@@ -298,6 +291,14 @@ async def get_auth_status(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=error_detail
         )
+
+@router.get("/permissions")
+async def get_permissions(
+    current_user: Optional[User] = Depends(get_current_user_optional),
+    db: Session = Depends(get_db),
+):
+    """获取当前用户权限码列表；未登录返回 standard 角色权限"""
+    return build_permissions_response(db, current_user)
 
 @router.post("/logout")
 async def logout(request: Request):

--- a/backend_api/gms_trade_observe_routes.py
+++ b/backend_api/gms_trade_observe_routes.py
@@ -15,6 +15,7 @@ from sqlalchemy.orm import Session
 
 from backend_api.auth import get_current_user
 from backend_api.database import get_db
+from backend_api.permissions import require_permission
 from backend_api.models import (
     GmsFormalTrade,
     GmsTradeObserveHistory,
@@ -624,6 +625,7 @@ def add_gms_trade_observe(
     body: GmsTradeObserveAddRequest,
     user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
+    _perm: None = Depends(require_permission("channel.screening.tab.gms.btn.refresh")),
 ):
     ensure_gms_trade_observe_schema(db)
     code = _normalize_code(body.code)
@@ -826,6 +828,7 @@ def remove_gms_trade_observe(
     item_id: int,
     user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
+    _perm: None = Depends(require_permission("channel.screening.tab.gms.btn.refresh")),
 ):
     ensure_gms_trade_observe_schema(db)
     row = (

--- a/backend_api/main.py
+++ b/backend_api/main.py
@@ -628,9 +628,38 @@ except ImportError as e:
 try:
     from .admin.users import router as admin_users_router
     print("admin_users_router 导入成功")
-except ImportError as e:
+except Exception as e:
+    import traceback
     print(f"admin_users_router 导入失败: {e}")
+    traceback.print_exc()
     admin_users_router = None
+
+try:
+    from .admin.roles import router as admin_roles_router
+    print("admin_roles_router 导入成功")
+except Exception as e:
+    import traceback
+    print(f"admin_roles_router 导入失败: {e}")
+    traceback.print_exc()
+    admin_roles_router = None
+
+try:
+    from .admin.permissions import router as admin_permissions_router
+    print("admin_permissions_router 导入成功")
+except Exception as e:
+    import traceback
+    print(f"admin_permissions_router 导入失败: {e}")
+    traceback.print_exc()
+    admin_permissions_router = None
+
+try:
+    from .admin.user_permissions import router as admin_user_permissions_router
+    print("admin_user_permissions_router 导入成功")
+except Exception as e:
+    import traceback
+    print(f"admin_user_permissions_router 导入失败: {e}")
+    traceback.print_exc()
+    admin_user_permissions_router = None
 
 # 尝试导入日志查询路由
 try:
@@ -707,6 +736,24 @@ if admin_users_router is not None:
     print("admin users路由注册成功")
 else:
     print("admin users路由未注册")
+
+if admin_user_permissions_router is not None:
+    app.include_router(admin_user_permissions_router)
+    print("admin user permissions路由注册成功")
+else:
+    print("admin user permissions路由未注册")
+
+if admin_roles_router is not None:
+    app.include_router(admin_roles_router)
+    print("admin roles路由注册成功")
+else:
+    print("admin roles路由未注册")
+
+if admin_permissions_router is not None:
+    app.include_router(admin_permissions_router)
+    print("admin permissions路由注册成功")
+else:
+    print("admin permissions路由未注册")
 
 # 注册日志查询路由
 if admin_logs_router is not None:

--- a/backend_api/models.py
+++ b/backend_api/models.py
@@ -85,6 +85,64 @@ class StockCodeTextPK(TypeDecorator):
         return str(value).strip()
 
 # SQLAlchemy 模型
+class FrontendRole(Base):
+    __tablename__ = "frontend_roles"
+
+    id = Column(Integer, primary_key=True, index=True)
+    code = Column(String(50), unique=True, nullable=False)
+    name = Column(String(100), nullable=False)
+    description = Column(Text, nullable=True)
+    is_system = Column(Boolean, default=False)
+    created_at = Column(DateTime, default=datetime.now)
+
+    permissions = relationship(
+        "FrontendPermission",
+        secondary="role_permissions",
+        back_populates="roles",
+    )
+    users = relationship("User", back_populates="frontend_role")
+
+
+class FrontendPermission(Base):
+    __tablename__ = "frontend_permissions"
+
+    id = Column(Integer, primary_key=True, index=True)
+    code = Column(String(200), unique=True, nullable=False)
+    name = Column(String(100), nullable=False)
+    level = Column(Integer, nullable=False)
+    parent_code = Column(String(200), nullable=True)
+    channel_code = Column(String(50), nullable=True)
+    sort_order = Column(Integer, default=0)
+    is_active = Column(Boolean, default=True)
+    created_at = Column(DateTime, default=datetime.now)
+
+    roles = relationship(
+        "FrontendRole",
+        secondary="role_permissions",
+        back_populates="permissions",
+    )
+
+
+class RolePermission(Base):
+    __tablename__ = "role_permissions"
+
+    role_id = Column(Integer, ForeignKey("frontend_roles.id", ondelete="CASCADE"), primary_key=True)
+    permission_id = Column(Integer, ForeignKey("frontend_permissions.id", ondelete="CASCADE"), primary_key=True)
+
+
+class UserPermission(Base):
+    """用户级权限覆盖：granted=True 额外授予，granted=False 相对角色撤销"""
+    __tablename__ = "user_permissions"
+
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), primary_key=True)
+    permission_id = Column(Integer, ForeignKey("frontend_permissions.id", ondelete="CASCADE"), primary_key=True)
+    granted = Column(Boolean, nullable=False)
+    created_at = Column(DateTime, default=datetime.now)
+
+    user = relationship("User", back_populates="permission_overrides")
+    permission = relationship("FrontendPermission")
+
+
 class User(Base):
     __tablename__ = "users"
     
@@ -93,6 +151,7 @@ class User(Base):
     email = Column(String, unique=True, nullable=False)
     password_hash = Column(String, nullable=False)
     role = Column(String, default="user")
+    role_id = Column(Integer, ForeignKey("frontend_roles.id"), nullable=True, index=True)
     status = Column(String, default="active")
     created_at = Column(DateTime, default=datetime.now)
     last_login = Column(DateTime, nullable=True)
@@ -102,6 +161,8 @@ class User(Base):
     wechat_userid = Column(String(100), nullable=True, index=True)  # 企业微信成员UserID，通知发送时优先使用
     wechat_type = Column(String(20), nullable=True)  # 'personal' 或 'enterprise'
     
+    frontend_role = relationship("FrontendRole", back_populates="users")
+    permission_overrides = relationship("UserPermission", back_populates="user", cascade="all, delete-orphan")
     watchlists = relationship("Watchlist", back_populates="user")
     watchlist_groups = relationship("WatchlistGroup", back_populates="user")
     push_configs = relationship("UserPushConfig", back_populates="user", uselist=True)
@@ -178,17 +239,20 @@ class UserBase(BaseModel):
 class UserCreate(UserBase):
     password: str
     role: Optional[str] = "user"
+    role_id: Optional[int] = None
 
 class UserUpdate(BaseModel):
     username: Optional[str] = None
     email: Optional[EmailStr] = None
     role: Optional[str] = None
+    role_id: Optional[int] = None
     status: Optional[str] = None
     wechat_userid: Optional[str] = None  # 企业微信成员UserID，用于微信通知
 
 class UserInDB(UserBase):
     id: int
     role: str
+    role_id: Optional[int] = None
     status: str
     created_at: datetime
     last_login: Optional[datetime] = None
@@ -196,6 +260,81 @@ class UserInDB(UserBase):
 
     class Config:
         from_attributes = True
+
+
+class FrontendRoleBase(BaseModel):
+    code: str
+    name: str
+    description: Optional[str] = None
+
+
+class FrontendRoleCreate(FrontendRoleBase):
+    pass
+
+
+class FrontendRoleUpdate(BaseModel):
+    name: Optional[str] = None
+    description: Optional[str] = None
+
+
+class FrontendRoleInDB(FrontendRoleBase):
+    id: int
+    is_system: bool
+    created_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class FrontendPermissionInDB(BaseModel):
+    id: int
+    code: str
+    name: str
+    level: int
+    parent_code: Optional[str] = None
+    channel_code: Optional[str] = None
+    sort_order: int
+    is_active: bool
+
+    class Config:
+        from_attributes = True
+
+
+class PermissionTreeNode(BaseModel):
+    id: int
+    code: str
+    name: str
+    level: int
+    parent_code: Optional[str] = None
+    channel_code: Optional[str] = None
+    sort_order: int
+    children: List["PermissionTreeNode"] = []
+
+
+class RolePermissionsUpdate(BaseModel):
+    permission_codes: List[str]
+
+
+class UserRoleInfo(BaseModel):
+    code: str
+    name: str
+
+
+class PermissionsResponse(BaseModel):
+    permissions: List[str]
+    role: UserRoleInfo
+    has_custom_permissions: bool = False
+
+
+class UserPermissionsUpdate(BaseModel):
+    permission_codes: List[str]
+
+
+class UserPermissionsDetail(BaseModel):
+    role: UserRoleInfo
+    role_permission_codes: List[str]
+    effective_permission_codes: List[str]
+    override_count: int
 
 class AdminBase(BaseModel):
     username: str
@@ -260,6 +399,8 @@ class Token(BaseModel):
     access_token: str
     token_type: str = "bearer"
     user: Optional[UserInDB] = None
+    permissions: Optional[List[str]] = None
+    role: Optional[UserRoleInfo] = None
 
     class Config:
         from_attributes = True

--- a/backend_api/models/__init__.py
+++ b/backend_api/models/__init__.py
@@ -49,6 +49,20 @@ try:
         UserInDB = getattr(models_module, 'UserInDB', None)
         UserCreate = getattr(models_module, 'UserCreate', None)
         UserUpdate = getattr(models_module, 'UserUpdate', None)
+        FrontendRole = getattr(models_module, 'FrontendRole', None)
+        FrontendPermission = getattr(models_module, 'FrontendPermission', None)
+        RolePermission = getattr(models_module, 'RolePermission', None)
+        FrontendRoleCreate = getattr(models_module, 'FrontendRoleCreate', None)
+        FrontendRoleUpdate = getattr(models_module, 'FrontendRoleUpdate', None)
+        FrontendRoleInDB = getattr(models_module, 'FrontendRoleInDB', None)
+        FrontendPermissionInDB = getattr(models_module, 'FrontendPermissionInDB', None)
+        PermissionTreeNode = getattr(models_module, 'PermissionTreeNode', None)
+        RolePermissionsUpdate = getattr(models_module, 'RolePermissionsUpdate', None)
+        UserPermissionsUpdate = getattr(models_module, 'UserPermissionsUpdate', None)
+        UserPermissionsDetail = getattr(models_module, 'UserPermissionsDetail', None)
+        UserPermission = getattr(models_module, 'UserPermission', None)
+        UserRoleInfo = getattr(models_module, 'UserRoleInfo', None)
+        PermissionsResponse = getattr(models_module, 'PermissionsResponse', None)
         MeanFrequencyResonanceIndicators = getattr(models_module, 'MeanFrequencyResonanceIndicators', None)
         GMSSignalTrace = getattr(models_module, 'GMSSignalTrace', None)
         GmsTraceRecomputeTask = getattr(models_module, 'GmsTraceRecomputeTask', None)
@@ -152,6 +166,20 @@ except Exception as e:
     UserInDB = None
     UserCreate = None
     UserUpdate = None
+    FrontendRole = None
+    FrontendPermission = None
+    RolePermission = None
+    FrontendRoleCreate = None
+    FrontendRoleUpdate = None
+    FrontendRoleInDB = None
+    FrontendPermissionInDB = None
+    PermissionTreeNode = None
+    RolePermissionsUpdate = None
+    UserPermissionsUpdate = None
+    UserPermissionsDetail = None
+    UserPermission = None
+    UserRoleInfo = None
+    PermissionsResponse = None
     MeanFrequencyResonanceIndicators = None
     GMSSignalTrace = None
     GmsTraceRecomputeTask = None
@@ -257,6 +285,20 @@ __all__ = [
     'UserInDB',
     'UserCreate',
     'UserUpdate',
+    'FrontendRole',
+    'FrontendPermission',
+    'RolePermission',
+    'FrontendRoleCreate',
+    'FrontendRoleUpdate',
+    'FrontendRoleInDB',
+    'FrontendPermissionInDB',
+    'PermissionTreeNode',
+    'RolePermissionsUpdate',
+    'UserPermissionsUpdate',
+    'UserPermissionsDetail',
+    'UserPermission',
+    'UserRoleInfo',
+    'PermissionsResponse',
     'MeanFrequencyResonanceIndicators',
     'GMSSignalTrace',
     'GmsTraceRecomputeTask',

--- a/backend_api/permission_registry_data.py
+++ b/backend_api/permission_registry_data.py
@@ -1,0 +1,70 @@
+"""
+前端权限资源注册表（权威数据源，供 sync API 与 seed 使用）
+权限码独立勾选，无父子继承。
+"""
+
+from typing import List, Dict, Any
+
+PERMISSION_REGISTRY: List[Dict[str, Any]] = [
+    # ── 一级：频道 ──
+    {"code": "channel.home", "name": "首页", "level": 1, "parent_code": None, "channel_code": "home", "sort_order": 10},
+    {"code": "channel.watchlist", "name": "自选股", "level": 1, "parent_code": None, "channel_code": "watchlist", "sort_order": 20},
+    {"code": "channel.quotes", "name": "行情", "level": 1, "parent_code": None, "channel_code": "quotes", "sort_order": 30},
+    {"code": "channel.screening", "name": "选股", "level": 1, "parent_code": None, "channel_code": "screening", "sort_order": 40},
+    {"code": "channel.analyze", "name": "分析", "level": 1, "parent_code": None, "channel_code": "analyze", "sort_order": 50},
+    {"code": "channel.news", "name": "资讯", "level": 1, "parent_code": None, "channel_code": "news", "sort_order": 60},
+    {"code": "channel.profile", "name": "我的", "level": 1, "parent_code": None, "channel_code": "profile", "sort_order": 70},
+
+    # ── 二级：选股标签页 ──
+    {"code": "channel.screening.tab.cyb_midline", "name": "创业板中线选股", "level": 2, "parent_code": "channel.screening", "channel_code": "screening", "sort_order": 10},
+    {"code": "channel.screening.tab.parking_apron", "name": "停机坪", "level": 2, "parent_code": "channel.screening", "channel_code": "screening", "sort_order": 20},
+    {"code": "channel.screening.tab.backtrace_ma250", "name": "回踩年线", "level": 2, "parent_code": "channel.screening", "channel_code": "screening", "sort_order": 30},
+    {"code": "channel.screening.tab.high_tight_flag", "name": "高而窄的旗形", "level": 2, "parent_code": "channel.screening", "channel_code": "screening", "sort_order": 40},
+    {"code": "channel.screening.tab.one_yang_three_lines", "name": "一阳穿三线", "level": 2, "parent_code": "channel.screening", "channel_code": "screening", "sort_order": 50},
+    {"code": "channel.screening.tab.gms", "name": "GMS均值引力动量", "level": 2, "parent_code": "channel.screening", "channel_code": "screening", "sort_order": 60},
+    {"code": "channel.screening.tab.pvfrs", "name": "PVFRS量价频幅度共振", "level": 2, "parent_code": "channel.screening", "channel_code": "screening", "sort_order": 70},
+    {"code": "channel.screening.tab.vsb", "name": "3倍量缩量突破", "level": 2, "parent_code": "channel.screening", "channel_code": "screening", "sort_order": 80},
+
+    # ── 三级：选股按钮 ──
+    {"code": "channel.screening.tab.cyb_midline.btn.refresh", "name": "刷新筛选", "level": 3, "parent_code": "channel.screening.tab.cyb_midline", "channel_code": "screening", "sort_order": 10},
+    {"code": "channel.screening.tab.gms.btn.refresh", "name": "GMS刷新", "level": 3, "parent_code": "channel.screening.tab.gms", "channel_code": "screening", "sort_order": 10},
+    {"code": "channel.screening.tab.gms.btn.export", "name": "GMS导出", "level": 3, "parent_code": "channel.screening.tab.gms", "channel_code": "screening", "sort_order": 20},
+    {"code": "channel.screening.tab.pvfrs.btn.refresh", "name": "PVFRS刷新", "level": 3, "parent_code": "channel.screening.tab.pvfrs", "channel_code": "screening", "sort_order": 10},
+    {"code": "channel.screening.tab.vsb.btn.refresh", "name": "VSB刷新", "level": 3, "parent_code": "channel.screening.tab.vsb", "channel_code": "screening", "sort_order": 10},
+    {"code": "channel.screening.tab.vsb.btn.add_observe", "name": "加入观察", "level": 3, "parent_code": "channel.screening.tab.vsb", "channel_code": "screening", "sort_order": 20},
+
+    # ── 二级：分析标签页 ──
+    {"code": "channel.analyze.tab.market", "name": "市场分析", "level": 2, "parent_code": "channel.analyze", "channel_code": "analyze", "sort_order": 10},
+    {"code": "channel.analyze.tab.technical", "name": "技术工具", "level": 2, "parent_code": "channel.analyze", "channel_code": "analyze", "sort_order": 20},
+    {"code": "channel.analyze.tab.strategy", "name": "投资策略", "level": 2, "parent_code": "channel.analyze", "channel_code": "analyze", "sort_order": 30},
+    {"code": "channel.analyze.tab.report", "name": "分析报告", "level": 2, "parent_code": "channel.analyze", "channel_code": "analyze", "sort_order": 40},
+
+    # ── 三级：分析按钮 ──
+    {"code": "channel.analyze.tab.technical.btn.analyze", "name": "开始分析", "level": 3, "parent_code": "channel.analyze.tab.technical", "channel_code": "analyze", "sort_order": 10},
+    {"code": "channel.analyze.tab.report.btn.export", "name": "导出报告", "level": 3, "parent_code": "channel.analyze.tab.report", "channel_code": "analyze", "sort_order": 10},
+
+    # ── 二级：个人中心标签页 ──
+    {"code": "channel.profile.tab.overview", "name": "投资概况", "level": 2, "parent_code": "channel.profile", "channel_code": "profile", "sort_order": 10},
+    {"code": "channel.profile.tab.portfolio", "name": "投资组合", "level": 2, "parent_code": "channel.profile", "channel_code": "profile", "sort_order": 20},
+    {"code": "channel.profile.tab.transactions", "name": "交易记录", "level": 2, "parent_code": "channel.profile", "channel_code": "profile", "sort_order": 30},
+    {"code": "channel.profile.tab.trading_logs", "name": "交易日志", "level": 2, "parent_code": "channel.profile", "channel_code": "profile", "sort_order": 40},
+    {"code": "channel.profile.tab.analysis", "name": "投资分析", "level": 2, "parent_code": "channel.profile", "channel_code": "profile", "sort_order": 50},
+    {"code": "channel.profile.tab.settings", "name": "账户设置", "level": 2, "parent_code": "channel.profile", "channel_code": "profile", "sort_order": 60},
+
+    # ── 三级：个人中心按钮 ──
+    {"code": "channel.profile.tab.settings.btn.change_password", "name": "修改密码", "level": 3, "parent_code": "channel.profile.tab.settings", "channel_code": "profile", "sort_order": 10},
+
+    # ── 二级：自选股标签页 ──
+    {"code": "channel.watchlist.tab.default", "name": "自选股列表", "level": 2, "parent_code": "channel.watchlist", "channel_code": "watchlist", "sort_order": 10},
+
+    # ── 三级：自选股按钮 ──
+    {"code": "channel.watchlist.tab.default.btn.add", "name": "添加自选股", "level": 3, "parent_code": "channel.watchlist.tab.default", "channel_code": "watchlist", "sort_order": 10},
+    {"code": "channel.watchlist.tab.default.btn.delete", "name": "删除自选股", "level": 3, "parent_code": "channel.watchlist.tab.default", "channel_code": "watchlist", "sort_order": 20},
+    {"code": "channel.watchlist.tab.default.btn.import", "name": "导入自选股", "level": 3, "parent_code": "channel.watchlist.tab.default", "channel_code": "watchlist", "sort_order": 30},
+]
+
+DEFAULT_ROLES = [
+    {"code": "standard", "name": "标准用户", "description": "默认角色，含全部已注册权限", "is_system": True},
+    {"code": "admin", "name": "前台管理员", "description": "前台管理员，含全部权限", "is_system": True},
+    {"code": "guest", "name": "访客", "description": "预留角色，本阶段不启用", "is_system": True},
+]

--- a/backend_api/permissions.py
+++ b/backend_api/permissions.py
@@ -1,0 +1,216 @@
+"""
+前端权限查询与校验
+"""
+
+from typing import List, Optional, Callable, Set
+
+from fastapi import Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from backend_api.database import get_db
+from backend_api.models import (
+    User,
+    FrontendRole,
+    FrontendPermission,
+    RolePermission,
+    UserPermission,
+    UserRoleInfo,
+    PermissionsResponse,
+    UserPermissionsDetail,
+)
+from backend_api.auth import get_current_user_optional
+
+
+def get_standard_role(db: Session) -> Optional[FrontendRole]:
+    return db.query(FrontendRole).filter(FrontendRole.code == "standard").first()
+
+
+def resolve_user_role(db: Session, user: Optional[User]) -> FrontendRole:
+    if user and user.role_id:
+        role = db.query(FrontendRole).filter(FrontendRole.id == user.role_id).first()
+        if role:
+            return role
+    if user and user.role:
+        role = db.query(FrontendRole).filter(FrontendRole.code == user.role).first()
+        if role:
+            return role
+    role = get_standard_role(db)
+    if not role:
+        raise HTTPException(status_code=500, detail="标准角色未配置，请先执行权限迁移")
+    return role
+
+
+def get_role_permission_codes(db: Session, role: FrontendRole) -> List[str]:
+    perms = (
+        db.query(FrontendPermission)
+        .join(RolePermission, RolePermission.permission_id == FrontendPermission.id)
+        .filter(
+            RolePermission.role_id == role.id,
+            FrontendPermission.is_active.is_(True),
+        )
+        .order_by(FrontendPermission.sort_order, FrontendPermission.code)
+        .all()
+    )
+    return [p.code for p in perms]
+
+
+def get_user_override_map(db: Session, user_id: int) -> dict:
+    """返回 {permission_code: granted}，granted=True 额外授予，False 撤销"""
+    rows = (
+        db.query(FrontendPermission.code, UserPermission.granted)
+        .join(UserPermission, UserPermission.permission_id == FrontendPermission.id)
+        .filter(UserPermission.user_id == user_id, FrontendPermission.is_active.is_(True))
+        .all()
+    )
+    return {code: granted for code, granted in rows}
+
+
+def get_effective_permission_codes(db: Session, user: Optional[User]) -> List[str]:
+    role = resolve_user_role(db, user)
+    effective: Set[str] = set(get_role_permission_codes(db, role))
+    if user and user.id:
+        for code, granted in get_user_override_map(db, user.id).items():
+            if granted:
+                effective.add(code)
+            else:
+                effective.discard(code)
+    return sorted(effective)
+
+
+def has_custom_permissions(db: Session, user: Optional[User]) -> bool:
+    if not user or not user.id:
+        return False
+    return db.query(UserPermission.user_id).filter(UserPermission.user_id == user.id).first() is not None
+
+
+def build_permissions_response(db: Session, user: Optional[User]) -> PermissionsResponse:
+    role = resolve_user_role(db, user)
+    codes = get_effective_permission_codes(db, user)
+    return PermissionsResponse(
+        permissions=codes,
+        role=UserRoleInfo(code=role.code, name=role.name),
+        has_custom_permissions=has_custom_permissions(db, user),
+    )
+
+
+def build_user_permissions_detail(db: Session, user: User) -> UserPermissionsDetail:
+    role = resolve_user_role(db, user)
+    role_codes = get_role_permission_codes(db, role)
+    effective = get_effective_permission_codes(db, user)
+    override_count = (
+        db.query(UserPermission).filter(UserPermission.user_id == user.id).count()
+    )
+    return UserPermissionsDetail(
+        role=UserRoleInfo(code=role.code, name=role.name),
+        role_permission_codes=role_codes,
+        effective_permission_codes=effective,
+        override_count=override_count,
+    )
+
+
+def set_user_effective_permissions(db: Session, user: User, effective_codes: List[str]) -> int:
+    """保存用户最终生效权限，自动计算相对角色的 grant/deny 覆盖"""
+    role = resolve_user_role(db, user)
+    role_codes = set(get_role_permission_codes(db, role))
+    effective = set(effective_codes)
+
+    all_perms = (
+        db.query(FrontendPermission)
+        .filter(FrontendPermission.is_active.is_(True))
+        .all()
+    )
+    code_to_id = {p.code: p.id for p in all_perms}
+
+    db.query(UserPermission).filter(UserPermission.user_id == user.id).delete()
+
+    override_count = 0
+    for perm in all_perms:
+        in_role = perm.code in role_codes
+        in_effective = perm.code in effective
+        if in_effective and not in_role:
+            db.add(UserPermission(user_id=user.id, permission_id=perm.id, granted=True))
+            override_count += 1
+        elif not in_effective and in_role:
+            db.add(UserPermission(user_id=user.id, permission_id=perm.id, granted=False))
+            override_count += 1
+
+    db.commit()
+    return override_count
+
+
+def clear_user_permission_overrides(db: Session, user_id: int) -> None:
+    db.query(UserPermission).filter(UserPermission.user_id == user_id).delete()
+    db.commit()
+
+
+def user_has_permission(db: Session, user: Optional[User], code: str) -> bool:
+    return code in get_effective_permission_codes(db, user)
+
+
+def require_permission(code: str) -> Callable:
+    async def _checker(
+        current_user: Optional[User] = Depends(get_current_user_optional),
+        db: Session = Depends(get_db),
+    ) -> None:
+        if not user_has_permission(db, current_user, code):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"无权限: {code}",
+            )
+
+    return _checker
+
+
+def build_permission_tree(db: Session) -> list:
+    perms = (
+        db.query(FrontendPermission)
+        .filter(FrontendPermission.is_active.is_(True))
+        .order_by(FrontendPermission.sort_order, FrontendPermission.code)
+        .all()
+    )
+    nodes = {}
+    roots = []
+    for p in perms:
+        nodes[p.code] = {
+            "id": p.id,
+            "code": p.code,
+            "name": p.name,
+            "level": p.level,
+            "parent_code": p.parent_code,
+            "channel_code": p.channel_code,
+            "sort_order": p.sort_order,
+            "children": [],
+        }
+    for p in perms:
+        node = nodes[p.code]
+        if p.parent_code and p.parent_code in nodes:
+            nodes[p.parent_code]["children"].append(node)
+        else:
+            roots.append(node)
+    return roots
+
+
+def sync_permissions_from_registry(db: Session) -> dict:
+    from backend_api.permission_registry_data import PERMISSION_REGISTRY
+
+    created = 0
+    updated = 0
+    for item in PERMISSION_REGISTRY:
+        existing = db.query(FrontendPermission).filter(FrontendPermission.code == item["code"]).first()
+        if existing:
+            for key, value in item.items():
+                setattr(existing, key, value)
+            existing.is_active = True
+            updated += 1
+        else:
+            db.add(FrontendPermission(**item))
+            created += 1
+    db.commit()
+
+    standard = get_standard_role(db)
+    admin_role = db.query(FrontendRole).filter(FrontendRole.code == "admin").first()
+    all_perms = db.query(FrontendPermission).filter(FrontendPermission.is_active.is_(True)).all()
+    for role in filter(None, [standard, admin_role]):
+        role.permissions = all_perms
+    db.commit()
+    return {"created": created, "updated": updated, "total": len(PERMISSION_REGISTRY)}

--- a/backend_api/triple_volume_trade_observe_routes.py
+++ b/backend_api/triple_volume_trade_observe_routes.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Session
 
 from backend_api.auth import get_current_user
 from backend_api.database import get_db
+from backend_api.permissions import require_permission
 from backend_api.models import TripleVolumeTradeObserveStock, User
 
 router = APIRouter(
@@ -155,6 +156,7 @@ def add_tvo_trade_observe(
     body: TvoTradeObserveAddRequest,
     user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
+    _perm: None = Depends(require_permission("channel.screening.tab.vsb.btn.add_observe")),
 ):
     code = _normalize_code(body.code)
     if not code:

--- a/backend_api/watchlist_manage.py
+++ b/backend_api/watchlist_manage.py
@@ -18,6 +18,7 @@ from .models import (
 )
 from .database import get_db
 from .auth import get_current_user
+from .permissions import require_permission
 
 router = APIRouter(prefix="/api/watchlist", tags=["watchlist"])
 
@@ -198,7 +199,8 @@ async def get_watchlist_groups(
 async def add_to_watchlist(
     watchlist: WatchlistCreate,
     current_user: User = Depends(get_current_user),
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    _perm: None = Depends(require_permission("channel.watchlist.tab.default.btn.add")),
 ):
     """添加股票到自选股"""
     try:
@@ -374,7 +376,8 @@ async def update_watchlist_group(
 async def remove_from_watchlist(
     watchlist_id: int,
     current_user: User = Depends(get_current_user),
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    _perm: None = Depends(require_permission("channel.watchlist.tab.default.btn.delete")),
 ):
     """从自选股中删除股票"""
     # 检查自选股是否存在
@@ -532,7 +535,8 @@ async def import_watchlist(
     file: UploadFile = File(...),
     group_name: str = "default",
     current_user: User = Depends(get_current_user),
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    _perm: None = Depends(require_permission("channel.watchlist.tab.default.btn.import")),
 ):
     """导入自选股列表"""
     try:

--- a/frontend/analysis.html
+++ b/frontend/analysis.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="css/analysis.css">
 </head>
 
-<body>
+<body data-channel="analyze">
     <script src="components/header.js"></script>
     <script>loadHeader('analyze');</script>
 
@@ -25,7 +25,7 @@
                     <h2>🔍 快速分析</h2>
                     <div class="stock-selector">
                         <input type="text" placeholder="输入股票代码或名称" class="stock-input">
-                        <button class="analyze-btn">开始分析</button>
+                        <button class="analyze-btn" data-perm="channel.analyze.tab.technical.btn.analyze">开始分析</button>
                     </div>
                 </div>
 
@@ -40,10 +40,10 @@
             <!-- 功能标签 -->
             <section class="analysis-tabs">
                 <div class="tab-nav">
-                    <button class="analysis-tab active" data-tab="market-analysis">市场分析</button>
-                    <button class="analysis-tab" data-tab="technical-tools">技术工具</button>
-                    <button class="analysis-tab" data-tab="strategy">投资策略</button>
-                    <button class="analysis-tab" data-tab="reports">分析报告</button>
+                    <button class="analysis-tab active" data-tab="market-analysis" data-perm="channel.analyze.tab.market">市场分析</button>
+                    <button class="analysis-tab" data-tab="technical-tools" data-perm="channel.analyze.tab.technical">技术工具</button>
+                    <button class="analysis-tab" data-tab="strategy" data-perm="channel.analyze.tab.strategy">投资策略</button>
+                    <button class="analysis-tab" data-tab="reports" data-perm="channel.analyze.tab.report">分析报告</button>
                 </div>
 
                 <!-- 市场分析 -->

--- a/frontend/components/header.html
+++ b/frontend/components/header.html
@@ -4,13 +4,13 @@
         <span class="logo-title">股票分析</span>
     </div>
     <nav class="nav-bar">
-        <a href="index.html" class="nav-link" id="nav-home">首页</a>
-        <a href="watchlist.html" class="nav-link" id="nav-watchlist">自选股</a>
-        <a href="markets.html" class="nav-link" id="nav-quotes">行情</a>
-        <a href="screening.html" class="nav-link" id="nav-screening">选股</a>
-        <a href="analysis.html" class="nav-link" id="nav-analyze">分析</a>
-        <a href="news.html" class="nav-link" id="nav-news">资讯</a>
-        <a href="profile.html" class="nav-link" id="nav-profile">我的</a>
+        <a href="index.html" class="nav-link" id="nav-home" data-perm="channel.home">首页</a>
+        <a href="watchlist.html" class="nav-link" id="nav-watchlist" data-perm="channel.watchlist">自选股</a>
+        <a href="markets.html" class="nav-link" id="nav-quotes" data-perm="channel.quotes">行情</a>
+        <a href="screening.html" class="nav-link" id="nav-screening" data-perm="channel.screening">选股</a>
+        <a href="analysis.html" class="nav-link" id="nav-analyze" data-perm="channel.analyze">分析</a>
+        <a href="news.html" class="nav-link" id="nav-news" data-perm="channel.news">资讯</a>
+        <a href="profile.html" class="nav-link" id="nav-profile" data-perm="channel.profile">我的</a>
     </nav>
     <div class="header-actions">
         <button class="search-btn">🔍</button>

--- a/frontend/components/header.js
+++ b/frontend/components/header.js
@@ -1,4 +1,33 @@
 // 动态加载header.html并处理登录状态
+function loadScript(src) {
+    return new Promise((resolve, reject) => {
+        if (document.querySelector(`script[src="${src}"]`)) {
+            resolve();
+            return;
+        }
+        const el = document.createElement('script');
+        el.src = src;
+        el.onload = resolve;
+        el.onerror = reject;
+        document.head.appendChild(el);
+    });
+}
+
+async function loadPermissionEngine() {
+    try {
+        await loadScript('js/permission-registry.js');
+        await loadScript('js/permission.js');
+        if (window.PermissionEngine) {
+            await PermissionEngine.init();
+            if (typeof PermissionEngine.decorateStrategyTabs === 'function') {
+                PermissionEngine.decorateStrategyTabs();
+            }
+        }
+    } catch (err) {
+        console.warn('权限引擎加载失败', err);
+    }
+}
+
 async function loadHeader(activePage) {
     console.log('开始加载header，当前页面:', activePage);
     
@@ -23,6 +52,8 @@ async function loadHeader(activePage) {
         console.log('开始初始化用户菜单...');
         initUserMenu();
     }, 100);
+
+    await loadPermissionEngine();
     
     // 延迟初始化股票搜索功能
     setTimeout(() => {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="css/home.css">
     <link rel="stylesheet" href="css/home_colors.css">
 </head>
-<body>
+<body data-channel="home">
 <script src="components/header.js"></script>
 <script>loadHeader('home');</script>
 

--- a/frontend/js/common.js
+++ b/frontend/js/common.js
@@ -126,6 +126,9 @@ const CommonUtils = {
                 const result = await response.json();
 
                 if (result.success && result.logged_in) {
+                    if (window.PermissionEngine && result.permissions) {
+                        PermissionEngine.setPermissions(result.permissions, result.role || null);
+                    }
                     return result.user;
                 } else {
                     // 不再强制跳转，只返回 null 表示未登录
@@ -162,6 +165,11 @@ const CommonUtils = {
             localStorage.removeItem('access_token');
             localStorage.removeItem('userInfo');
             localStorage.removeItem('token');
+            localStorage.removeItem('userPermissions');
+            localStorage.removeItem('userRole');
+            if (window.PermissionEngine) {
+                PermissionEngine.setPermissions([], null);
+            }
             if (window.location.pathname.includes('login.html')) return;
             let url = 'login.html';
             if (includeReturn) {
@@ -220,7 +228,9 @@ const CommonUtils = {
                     'token',
                     'rememberedUsername',
                     'adminLoggedIn',
-                    'adminData'
+                    'adminData',
+                    'userPermissions',
+                    'userRole'
                 ].forEach(function (k) {
                     try { localStorage.removeItem(k); } catch (e) {}
                 });

--- a/frontend/js/login.js
+++ b/frontend/js/login.js
@@ -167,7 +167,7 @@ const LoginPage = {
             
             if (response.ok && result.access_token && result.user) {
                 // 登录成功，保存token
-                this.handleLoginSuccess(result.user, rememberMe, result.access_token);
+                this.handleLoginSuccess(result.user, rememberMe, result.access_token, result.permissions, result.role);
             } else {
                 // 登录失败
                 this.showToast(result.message || '登录失败', 'error');
@@ -194,7 +194,7 @@ const LoginPage = {
     },
 
     // 登录成功处理
-    handleLoginSuccess(user, rememberMe, accessToken) {
+    handleLoginSuccess(user, rememberMe, accessToken, permissions, role) {
         // 添加登录成功动画效果
         this.playSuccessAnimation();
         
@@ -209,6 +209,12 @@ const LoginPage = {
         // 保存 access_token
         if (accessToken) {
             localStorage.setItem('access_token', accessToken);
+        }
+        if (window.PermissionEngine && permissions) {
+            PermissionEngine.setPermissions(permissions, role || null);
+        } else if (permissions) {
+            localStorage.setItem('userPermissions', JSON.stringify(permissions));
+            if (role) localStorage.setItem('userRole', JSON.stringify(role));
         }
         // 如果记住我，保存用户名
         if (rememberMe) {

--- a/frontend/js/permission-registry.js
+++ b/frontend/js/permission-registry.js
@@ -1,0 +1,60 @@
+/**
+ * 前端权限资源注册表（与 backend_api/permission_registry_data.py 保持同步）
+ */
+window.PERMISSION_REGISTRY = [
+  { code: 'channel.home', name: '首页', level: 1, parent_code: null, channel_code: 'home', sort_order: 10 },
+  { code: 'channel.watchlist', name: '自选股', level: 1, parent_code: null, channel_code: 'watchlist', sort_order: 20 },
+  { code: 'channel.quotes', name: '行情', level: 1, parent_code: null, channel_code: 'quotes', sort_order: 30 },
+  { code: 'channel.screening', name: '选股', level: 1, parent_code: null, channel_code: 'screening', sort_order: 40 },
+  { code: 'channel.analyze', name: '分析', level: 1, parent_code: null, channel_code: 'analyze', sort_order: 50 },
+  { code: 'channel.news', name: '资讯', level: 1, parent_code: null, channel_code: 'news', sort_order: 60 },
+  { code: 'channel.profile', name: '我的', level: 1, parent_code: null, channel_code: 'profile', sort_order: 70 },
+
+  { code: 'channel.screening.tab.cyb_midline', name: '创业板中线选股', level: 2, parent_code: 'channel.screening', channel_code: 'screening', sort_order: 10 },
+  { code: 'channel.screening.tab.parking_apron', name: '停机坪', level: 2, parent_code: 'channel.screening', channel_code: 'screening', sort_order: 20 },
+  { code: 'channel.screening.tab.backtrace_ma250', name: '回踩年线', level: 2, parent_code: 'channel.screening', channel_code: 'screening', sort_order: 30 },
+  { code: 'channel.screening.tab.high_tight_flag', name: '高而窄的旗形', level: 2, parent_code: 'channel.screening', channel_code: 'screening', sort_order: 40 },
+  { code: 'channel.screening.tab.one_yang_three_lines', name: '一阳穿三线', level: 2, parent_code: 'channel.screening', channel_code: 'screening', sort_order: 50 },
+  { code: 'channel.screening.tab.gms', name: 'GMS均值引力动量', level: 2, parent_code: 'channel.screening', channel_code: 'screening', sort_order: 60 },
+  { code: 'channel.screening.tab.pvfrs', name: 'PVFRS量价频幅度共振', level: 2, parent_code: 'channel.screening', channel_code: 'screening', sort_order: 70 },
+  { code: 'channel.screening.tab.vsb', name: '3倍量缩量突破', level: 2, parent_code: 'channel.screening', channel_code: 'screening', sort_order: 80 },
+
+  { code: 'channel.screening.tab.cyb_midline.btn.refresh', name: '刷新筛选', level: 3, parent_code: 'channel.screening.tab.cyb_midline', channel_code: 'screening', sort_order: 10 },
+  { code: 'channel.screening.tab.gms.btn.refresh', name: 'GMS刷新', level: 3, parent_code: 'channel.screening.tab.gms', channel_code: 'screening', sort_order: 10 },
+  { code: 'channel.screening.tab.gms.btn.export', name: 'GMS导出', level: 3, parent_code: 'channel.screening.tab.gms', channel_code: 'screening', sort_order: 20 },
+  { code: 'channel.screening.tab.pvfrs.btn.refresh', name: 'PVFRS刷新', level: 3, parent_code: 'channel.screening.tab.pvfrs', channel_code: 'screening', sort_order: 10 },
+  { code: 'channel.screening.tab.vsb.btn.refresh', name: 'VSB刷新', level: 3, parent_code: 'channel.screening.tab.vsb', channel_code: 'screening', sort_order: 10 },
+  { code: 'channel.screening.tab.vsb.btn.add_observe', name: '加入观察', level: 3, parent_code: 'channel.screening.tab.vsb', channel_code: 'screening', sort_order: 20 },
+
+  { code: 'channel.analyze.tab.market', name: '市场分析', level: 2, parent_code: 'channel.analyze', channel_code: 'analyze', sort_order: 10 },
+  { code: 'channel.analyze.tab.technical', name: '技术工具', level: 2, parent_code: 'channel.analyze', channel_code: 'analyze', sort_order: 20 },
+  { code: 'channel.analyze.tab.strategy', name: '投资策略', level: 2, parent_code: 'channel.analyze', channel_code: 'analyze', sort_order: 30 },
+  { code: 'channel.analyze.tab.report', name: '分析报告', level: 2, parent_code: 'channel.analyze', channel_code: 'analyze', sort_order: 40 },
+  { code: 'channel.analyze.tab.technical.btn.analyze', name: '开始分析', level: 3, parent_code: 'channel.analyze.tab.technical', channel_code: 'analyze', sort_order: 10 },
+  { code: 'channel.analyze.tab.report.btn.export', name: '导出报告', level: 3, parent_code: 'channel.analyze.tab.report', channel_code: 'analyze', sort_order: 10 },
+
+  { code: 'channel.profile.tab.overview', name: '投资概况', level: 2, parent_code: 'channel.profile', channel_code: 'profile', sort_order: 10 },
+  { code: 'channel.profile.tab.portfolio', name: '投资组合', level: 2, parent_code: 'channel.profile', channel_code: 'profile', sort_order: 20 },
+  { code: 'channel.profile.tab.transactions', name: '交易记录', level: 2, parent_code: 'channel.profile', channel_code: 'profile', sort_order: 30 },
+  { code: 'channel.profile.tab.trading_logs', name: '交易日志', level: 2, parent_code: 'channel.profile', channel_code: 'profile', sort_order: 40 },
+  { code: 'channel.profile.tab.analysis', name: '投资分析', level: 2, parent_code: 'channel.profile', channel_code: 'profile', sort_order: 50 },
+  { code: 'channel.profile.tab.settings', name: '账户设置', level: 2, parent_code: 'channel.profile', channel_code: 'profile', sort_order: 60 },
+  { code: 'channel.profile.tab.settings.btn.change_password', name: '修改密码', level: 3, parent_code: 'channel.profile.tab.settings', channel_code: 'profile', sort_order: 10 },
+
+  { code: 'channel.watchlist.tab.default', name: '自选股列表', level: 2, parent_code: 'channel.watchlist', channel_code: 'watchlist', sort_order: 10 },
+  { code: 'channel.watchlist.tab.default.btn.add', name: '添加自选股', level: 3, parent_code: 'channel.watchlist.tab.default', channel_code: 'watchlist', sort_order: 10 },
+  { code: 'channel.watchlist.tab.default.btn.delete', name: '删除自选股', level: 3, parent_code: 'channel.watchlist.tab.default', channel_code: 'watchlist', sort_order: 20 },
+  { code: 'channel.watchlist.tab.default.btn.import', name: '导入自选股', level: 3, parent_code: 'channel.watchlist.tab.default', channel_code: 'watchlist', sort_order: 30 }
+];
+
+/** 策略 tab data-strategy → 权限码映射 */
+window.PERMISSION_TAB_MAP = {
+  'cyb-midline': 'channel.screening.tab.cyb_midline',
+  'parking-apron': 'channel.screening.tab.parking_apron',
+  'backtrace-ma250': 'channel.screening.tab.backtrace_ma250',
+  'high-tight-flag': 'channel.screening.tab.high_tight_flag',
+  'one-yang-three-lines': 'channel.screening.tab.one_yang_three_lines',
+  gms: 'channel.screening.tab.gms',
+  pvfrs: 'channel.screening.tab.pvfrs',
+  'volume-shrink-breakout': 'channel.screening.tab.vsb'
+};

--- a/frontend/js/permission.js
+++ b/frontend/js/permission.js
@@ -91,7 +91,13 @@ const PermissionEngine = {
       if (!visible.length) continue;
       const active = tabs.find(t => t.classList.contains('active'));
       if (active && this.has(active.getAttribute('data-perm'))) continue;
-      visible[0].click();
+      const first = visible[0];
+      const strategy = first.getAttribute('data-strategy');
+      if (strategy && window.ScreeningPage && typeof ScreeningPage.switchStrategy === 'function') {
+        ScreeningPage.switchStrategy(strategy);
+      } else {
+        first.click();
+      }
       break;
     }
   },

--- a/frontend/js/permission.js
+++ b/frontend/js/permission.js
@@ -1,0 +1,138 @@
+/**
+ * 前端权限引擎：频道 / 标签页 / 按钮三级控制
+ */
+const PermissionEngine = {
+  permissions: new Set(),
+  role: null,
+  _initialized: false,
+
+  async init() {
+    try {
+      const base = (typeof Config !== 'undefined' && Config.getApiBaseUrl) ? Config.getApiBaseUrl() : '';
+      const resp = await smartFetch(base + '/api/auth/permissions');
+      if (!resp.ok) {
+        console.warn('[PermissionEngine] 获取权限失败', resp.status);
+        return;
+      }
+      const data = await resp.json();
+      this.setPermissions(data.permissions || [], data.role || null);
+      this.applyToPage();
+      this._initialized = true;
+    } catch (err) {
+      console.warn('[PermissionEngine] init 异常', err);
+    }
+  },
+
+  setPermissions(codes, role) {
+    this.permissions = new Set(codes || []);
+    this.role = role;
+    try {
+      localStorage.setItem('userPermissions', JSON.stringify(codes || []));
+      if (role) localStorage.setItem('userRole', JSON.stringify(role));
+    } catch (_) { /* ignore */ }
+  },
+
+  loadFromCache() {
+    try {
+      const cached = localStorage.getItem('userPermissions');
+      const roleCached = localStorage.getItem('userRole');
+      if (cached) {
+        this.permissions = new Set(JSON.parse(cached));
+      }
+      if (roleCached) {
+        this.role = JSON.parse(roleCached);
+      }
+    } catch (_) { /* ignore */ }
+  },
+
+  has(code) {
+    if (!code) return true;
+    return this.permissions.has(code);
+  },
+
+  applyToPage() {
+    document.querySelectorAll('[data-perm]').forEach(el => {
+      const code = el.getAttribute('data-perm');
+      if (!this.has(code)) {
+        el.style.display = 'none';
+        el.setAttribute('aria-hidden', 'true');
+      } else {
+        if (el.style.display === 'none' && !el.dataset.permHiddenByOther) {
+          el.style.removeProperty('display');
+        }
+        el.removeAttribute('aria-hidden');
+      }
+    });
+    this.guardChannel();
+    this.activateFirstAllowedTab();
+    this.handleDeniedQuery();
+  },
+
+  guardChannel() {
+    const channel = document.body && document.body.getAttribute('data-channel');
+    if (!channel) return;
+    const code = channel.startsWith('channel.') ? channel : 'channel.' + channel;
+    if (!this.has(code)) {
+      window.location.href = 'index.html?denied=1';
+    }
+  },
+
+  activateFirstAllowedTab() {
+    const tabSelectors = [
+      '.strategy-tab[data-perm]',
+      '.analysis-tab[data-perm]',
+      '.profile-tab[data-perm]',
+      '.category-tab[data-perm]'
+    ];
+    for (const selector of tabSelectors) {
+      const tabs = Array.from(document.querySelectorAll(selector));
+      if (!tabs.length) continue;
+      const visible = tabs.filter(t => this.has(t.getAttribute('data-perm')));
+      if (!visible.length) continue;
+      const active = tabs.find(t => t.classList.contains('active'));
+      if (active && this.has(active.getAttribute('data-perm'))) continue;
+      visible[0].click();
+      break;
+    }
+  },
+
+  handleDeniedQuery() {
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('denied') === '1') {
+      if (typeof CommonUtils !== 'undefined' && CommonUtils.showToast) {
+        CommonUtils.showToast('您没有访问该页面的权限', 'warning');
+      } else {
+        console.warn('无权限访问该页面');
+      }
+      params.delete('denied');
+      const qs = params.toString();
+      const url = window.location.pathname + (qs ? '?' + qs : '') + window.location.hash;
+      window.history.replaceState({}, '', url);
+    }
+  },
+
+  decorateStrategyTabs() {
+    if (!window.PERMISSION_TAB_MAP) return;
+    Object.entries(window.PERMISSION_TAB_MAP).forEach(([strategy, perm]) => {
+      const tab = document.querySelector(`.strategy-tab[data-strategy="${strategy}"]`);
+      if (tab) tab.setAttribute('data-perm', perm);
+      const content = document.getElementById(`${strategy}-content`);
+      if (content) content.setAttribute('data-perm', perm);
+    });
+    document.querySelectorAll('.refresh-btn[data-strategy]').forEach(btn => {
+      const strategy = btn.getAttribute('data-strategy');
+      const tabPerm = window.PERMISSION_TAB_MAP[strategy];
+      if (!tabPerm) return;
+      const suffix = tabPerm.replace('channel.screening.tab.', '');
+      btn.setAttribute('data-perm', 'channel.screening.tab.' + suffix + '.btn.refresh');
+    });
+    this.applyToPage();
+  }
+};
+
+window.PermissionEngine = PermissionEngine;
+
+document.addEventListener('DOMContentLoaded', () => {
+  PermissionEngine.loadFromCache();
+  PermissionEngine.init();
+});

--- a/frontend/js/screening.js
+++ b/frontend/js/screening.js
@@ -58,7 +58,34 @@ const ScreeningPage = {
         this.initStrategyTabs();
         this.initVsbIntegratedTabs();
         this.initGmsIntegratedTabs();
+        // 权限引擎需在 Tab 事件绑定后再应用，以便正确切换到首个有权限的策略
+        if (typeof loadPermissionEngine === 'function') {
+            await loadPermissionEngine();
+        }
+        this.ensureActiveStrategyVisible();
         this.applyVsbHashOnLoad();
+    },
+
+    /** 默认策略 Tab 被权限隐藏时，切换到第一个可见且有权限的策略 */
+    ensureActiveStrategyVisible() {
+        const activeContent = document.querySelector('.strategy-content.active');
+        const contentHidden = !activeContent
+            || activeContent.getAttribute('aria-hidden') === 'true'
+            || getComputedStyle(activeContent).display === 'none';
+        if (!contentHidden) return;
+
+        const legacyHidden = new Set(['parking-apron', 'backtrace-ma250', 'high-tight-flag']);
+        const tabs = Array.from(document.querySelectorAll('.strategy-tab[data-strategy]'));
+        const pick = tabs.find((t) => {
+            if (legacyHidden.has(t.dataset.strategy)) return false;
+            if (getComputedStyle(t).display === 'none') return false;
+            const perm = t.getAttribute('data-perm');
+            if (perm && window.PermissionEngine && !PermissionEngine.has(perm)) return false;
+            return true;
+        });
+        if (pick) {
+            this.switchStrategy(pick.dataset.strategy);
+        }
     },
 
     // 初始化策略标签页
@@ -2267,13 +2294,6 @@ const ScreeningPage = {
                 if (response.ok) {
                     const headerHtml = await response.text();
                     headerContainer.innerHTML = headerHtml;
-
-                    // 加载权限引擎并应用到选股策略 Tab / 内容区
-                    if (typeof loadPermissionEngine === 'function') {
-                        await loadPermissionEngine();
-                    } else {
-                        console.warn('loadPermissionEngine 未找到，策略 Tab 权限控制可能未生效');
-                    }
 
                     // 等待DOM更新后初始化头部功能
                     setTimeout(() => {

--- a/frontend/js/screening.js
+++ b/frontend/js/screening.js
@@ -2268,6 +2268,13 @@ const ScreeningPage = {
                     const headerHtml = await response.text();
                     headerContainer.innerHTML = headerHtml;
 
+                    // 加载权限引擎并应用到选股策略 Tab / 内容区
+                    if (typeof loadPermissionEngine === 'function') {
+                        await loadPermissionEngine();
+                    } else {
+                        console.warn('loadPermissionEngine 未找到，策略 Tab 权限控制可能未生效');
+                    }
+
                     // 等待DOM更新后初始化头部功能
                     setTimeout(() => {
                         // 高亮当前频道

--- a/frontend/markets.html
+++ b/frontend/markets.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="css/common.css">
     <link rel="stylesheet" href="css/markets.css">
 </head>
-<body>
+<body data-channel="quotes">
 <script src="components/header.js"></script>
 <script>loadHeader('quotes');</script>
     <!-- 主要内容 -->

--- a/frontend/news.html
+++ b/frontend/news.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="css/news.css">
     <link rel="icon" href="favicon.ico" type="image/x-icon">
 </head>
-<body>
+<body data-channel="news">
     <!-- 头部导航 -->
     <div id="header-container"></div>
 

--- a/frontend/profile.html
+++ b/frontend/profile.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="css/profile.css">
 </head>
 
-<body>
+<body data-channel="profile">
     <script src="components/header.js"></script>
     <script>loadHeader('profile');</script>
     <!-- 主要内容 -->
@@ -53,12 +53,12 @@
             <!-- 内容标签 -->
             <section class="profile-tabs">
                 <div class="tab-nav">
-                    <button class="profile-tab active" data-tab="overview">投资概况</button>
-                    <button class="profile-tab" data-tab="portfolio">投资组合</button>
-                    <button class="profile-tab" data-tab="transactions">交易记录</button>
-                    <button class="profile-tab" data-tab="trading-logs">交易日志</button>
-                    <button class="profile-tab" data-tab="analysis">投资分析</button>
-                    <button class="profile-tab" data-tab="settings">账户设置</button>
+                    <button class="profile-tab active" data-tab="overview" data-perm="channel.profile.tab.overview">投资概况</button>
+                    <button class="profile-tab" data-tab="portfolio" data-perm="channel.profile.tab.portfolio">投资组合</button>
+                    <button class="profile-tab" data-tab="transactions" data-perm="channel.profile.tab.transactions">交易记录</button>
+                    <button class="profile-tab" data-tab="trading-logs" data-perm="channel.profile.tab.trading_logs">交易日志</button>
+                    <button class="profile-tab" data-tab="analysis" data-perm="channel.profile.tab.analysis">投资分析</button>
+                    <button class="profile-tab" data-tab="settings" data-perm="channel.profile.tab.settings">账户设置</button>
                 </div>
 
                 <!-- 投资概况 -->

--- a/frontend/screening.html
+++ b/frontend/screening.html
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="css/screening.css">
 </head>
 
-<body>
+<body data-channel="screening">
     <div id="header-container"></div>
 
     <main class="screening-container">

--- a/frontend/watchlist.html
+++ b/frontend/watchlist.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="css/watchlist.css">
 </head>
 
-<body>
+<body data-channel="watchlist">
     <script src="components/header.js"></script>
     <script>loadHeader('watchlist');</script>
     <!-- 主要内容 -->
@@ -23,8 +23,8 @@
                     <span class="stock-count">共 <span id="stockCount">6</span> 只股票</span>
                 </div>
                 <div class="toolbar-right">
-                    <button class="btn btn-primary add-stock-btn">+ 添加</button>
-                    <button class="btn btn-secondary import-btn">导入</button>
+                    <button class="btn btn-primary add-stock-btn" data-perm="channel.watchlist.tab.default.btn.add">+ 添加</button>
+                    <button class="btn btn-secondary import-btn" data-perm="channel.watchlist.tab.default.btn.import">导入</button>
                     <div class="export-dropdown">
                         <button class="btn btn-secondary export-dropdown-btn">导出</button>
                         <div class="export-menu">

--- a/migrations/add_frontend_permissions.py
+++ b/migrations/add_frontend_permissions.py
@@ -1,0 +1,255 @@
+"""
+数据库迁移 - 前端三级权限控制表
+创建 frontend_roles / frontend_permissions / role_permissions，扩展 users.role_id
+
+生产环境 lock timeout 常见原因：
+  - backend/uvicorn 仍在运行，存在 idle in transaction 或并发 DDL
+  - 建议：先停止后端服务，或低峰期执行
+
+环境变量：
+  MIGRATION_LOCK_TIMEOUT_MS  锁等待毫秒，默认 300000（5 分钟）
+  MIGRATION_MAX_RETRIES        遇锁超时重试次数，默认 5
+"""
+
+import sys
+import os
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.exc import OperationalError
+from backend_api.config import DATABASE_CONFIG
+import logging
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+LOCK_TIMEOUT_MS = int(os.environ.get("MIGRATION_LOCK_TIMEOUT_MS", "300000"))
+MAX_RETRIES = int(os.environ.get("MIGRATION_MAX_RETRIES", "5"))
+RETRY_WAIT_SEC = int(os.environ.get("MIGRATION_RETRY_WAIT_SEC", "30"))
+
+
+def _make_engine():
+    return create_engine(
+        DATABASE_CONFIG["url"],
+        pool_pre_ping=True,
+        pool_size=1,
+        max_overflow=0,
+        connect_args={
+            "connect_timeout": 15,
+            "options": f"-c lock_timeout={LOCK_TIMEOUT_MS} -c statement_timeout=900000",
+        },
+    )
+
+
+def _step(label: str):
+    logger.info(">>> %s ...", label)
+    sys.stdout.flush()
+
+
+def _done(label: str, elapsed: float):
+    logger.info("<<< %s 完成 (%.1fs)", label, elapsed)
+    sys.stdout.flush()
+
+
+def _is_lock_error(exc: BaseException) -> bool:
+    msg = str(exc).lower()
+    return "lock timeout" in msg or "locknotavailable" in msg or "canceling statement due to lock" in msg
+
+
+def _run_with_retry(engine, label: str, fn):
+    """遇锁超时自动重试（生产环境常见）"""
+    for attempt in range(1, MAX_RETRIES + 1):
+        try:
+            t0 = time.time()
+            _step(label if attempt == 1 else f"{label} (重试 {attempt}/{MAX_RETRIES})")
+            fn()
+            _done(label, time.time() - t0)
+            return
+        except OperationalError as e:
+            if _is_lock_error(e) and attempt < MAX_RETRIES:
+                logger.warning(
+                    "锁等待超时，%ds 后重试 (%d/%d)。可先执行: python migrations/diagnose_db_locks.py",
+                    RETRY_WAIT_SEC, attempt, MAX_RETRIES,
+                )
+                sys.stdout.flush()
+                time.sleep(RETRY_WAIT_SEC)
+                continue
+            raise
+
+
+def _table_exists(conn, name: str) -> bool:
+    r = conn.execute(text("""
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'public' AND table_name = :name
+    """), {"name": name})
+    return r.fetchone() is not None
+
+
+def upgrade():
+    engine = _make_engine()
+    logger.info(
+        "数据库: %s | lock_timeout=%dms | max_retries=%d",
+        DATABASE_CONFIG["url"].split("@")[-1] if "@" in DATABASE_CONFIG["url"] else "(hidden)",
+        LOCK_TIMEOUT_MS,
+        MAX_RETRIES,
+    )
+    sys.stdout.flush()
+
+    try:
+        from backend_api.permission_registry_data import PERMISSION_REGISTRY, DEFAULT_ROLES
+    except ModuleNotFoundError as e:
+        logger.error("缺少 backend_api/permission_registry_data.py，请先部署完整代码。")
+        raise SystemExit(1) from e
+
+    def create_frontend_roles():
+        with engine.begin() as conn:
+            if _table_exists(conn, "frontend_roles"):
+                logger.info("    frontend_roles 已存在，跳过 CREATE")
+                return
+            conn.execute(text("""
+                CREATE TABLE frontend_roles (
+                    id          SERIAL PRIMARY KEY,
+                    code        VARCHAR(50) UNIQUE NOT NULL,
+                    name        VARCHAR(100) NOT NULL,
+                    description TEXT,
+                    is_system   BOOLEAN DEFAULT FALSE,
+                    created_at  TIMESTAMP DEFAULT NOW()
+                )
+            """))
+
+    def create_frontend_permissions():
+        with engine.begin() as conn:
+            if _table_exists(conn, "frontend_permissions"):
+                logger.info("    frontend_permissions 已存在，跳过 CREATE")
+                return
+            conn.execute(text("""
+                CREATE TABLE frontend_permissions (
+                    id           SERIAL PRIMARY KEY,
+                    code         VARCHAR(200) UNIQUE NOT NULL,
+                    name         VARCHAR(100) NOT NULL,
+                    level        SMALLINT NOT NULL,
+                    parent_code  VARCHAR(200),
+                    channel_code VARCHAR(50),
+                    sort_order   INT DEFAULT 0,
+                    is_active    BOOLEAN DEFAULT TRUE,
+                    created_at   TIMESTAMP DEFAULT NOW()
+                )
+            """))
+
+    def create_role_permissions():
+        with engine.begin() as conn:
+            if _table_exists(conn, "role_permissions"):
+                logger.info("    role_permissions 已存在，跳过 CREATE")
+                return
+            conn.execute(text("""
+                CREATE TABLE role_permissions (
+                    role_id       INT NOT NULL REFERENCES frontend_roles(id) ON DELETE CASCADE,
+                    permission_id INT NOT NULL REFERENCES frontend_permissions(id) ON DELETE CASCADE,
+                    PRIMARY KEY (role_id, permission_id)
+                )
+            """))
+
+    _run_with_retry(engine, "1/8 创建 frontend_roles", create_frontend_roles)
+    _run_with_retry(engine, "2/8 创建 frontend_permissions", create_frontend_permissions)
+    _run_with_retry(engine, "3/8 创建 role_permissions", create_role_permissions)
+
+    def alter_users_role_id():
+        with engine.begin() as conn:
+            _step("4/8 检查 users.role_id")
+            result = conn.execute(text("""
+                SELECT column_name FROM information_schema.columns
+                WHERE table_schema = 'public' AND table_name = 'users' AND column_name = 'role_id'
+            """))
+            has_col = result.fetchone() is not None
+            if has_col:
+                logger.info("    users.role_id 已存在，跳过")
+                return
+            logger.info("    ALTER TABLE users ADD COLUMN role_id（需 users 表锁，建议已停 backend）")
+            sys.stdout.flush()
+            conn.execute(text("ALTER TABLE users ADD COLUMN role_id INTEGER"))
+            conn.execute(text("""
+                DO $$
+                BEGIN
+                    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'users_role_id_fkey') THEN
+                        ALTER TABLE users ADD CONSTRAINT users_role_id_fkey
+                            FOREIGN KEY (role_id) REFERENCES frontend_roles(id);
+                    END IF;
+                END $$
+            """))
+            conn.execute(text("CREATE INDEX IF NOT EXISTS idx_users_role_id ON users(role_id)"))
+            _done("4/8 users.role_id", 0)
+
+    _run_with_retry(engine, "4/8 扩展 users.role_id", alter_users_role_id)
+
+    def seed_data():
+        with engine.begin() as conn:
+            for role in DEFAULT_ROLES:
+                conn.execute(text("""
+                    INSERT INTO frontend_roles (code, name, description, is_system)
+                    VALUES (:code, :name, :description, :is_system)
+                    ON CONFLICT (code) DO NOTHING
+                """), role)
+            for i, perm in enumerate(PERMISSION_REGISTRY, 1):
+                conn.execute(text("""
+                    INSERT INTO frontend_permissions (code, name, level, parent_code, channel_code, sort_order)
+                    VALUES (:code, :name, :level, :parent_code, :channel_code, :sort_order)
+                    ON CONFLICT (code) DO UPDATE SET
+                        name = EXCLUDED.name, level = EXCLUDED.level,
+                        parent_code = EXCLUDED.parent_code, channel_code = EXCLUDED.channel_code,
+                        sort_order = EXCLUDED.sort_order, is_active = TRUE
+                """), perm)
+                if i % 10 == 0 or i == len(PERMISSION_REGISTRY):
+                    logger.info("    权限进度 %d/%d", i, len(PERMISSION_REGISTRY))
+            conn.execute(text("""
+                INSERT INTO role_permissions (role_id, permission_id)
+                SELECT r.id, p.id FROM frontend_roles r
+                CROSS JOIN frontend_permissions p
+                WHERE r.code IN ('standard', 'admin') AND p.is_active = TRUE
+                ON CONFLICT DO NOTHING
+            """))
+
+    _run_with_retry(engine, "5/8 写入角色与权限 seed", seed_data)
+
+    def backfill_users():
+        with engine.begin() as conn:
+            r1 = conn.execute(text("""
+                UPDATE users u SET role_id = r.id FROM frontend_roles r
+                WHERE u.role_id IS NULL AND (
+                    (u.role = 'admin' AND r.code = 'admin') OR
+                    (u.role = 'guest' AND r.code = 'guest') OR
+                    ((u.role IS NULL OR u.role IN ('user', 'standard')) AND r.code = 'standard')
+                )
+            """))
+            r2 = conn.execute(text("""
+                UPDATE users u SET role_id = r.id FROM frontend_roles r
+                WHERE u.role_id IS NULL AND r.code = 'standard'
+            """))
+            logger.info("    回填行数: %s + %s", getattr(r1, "rowcount", "?"), getattr(r2, "rowcount", "?"))
+
+    _run_with_retry(engine, "6/8 回填 users.role_id", backfill_users)
+
+    logger.info("✅ 前端权限控制表迁移全部完成")
+    sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    try:
+        upgrade()
+    except Exception as e:
+        logger.error("❌ 迁移失败: %s", e)
+        if _is_lock_error(e):
+            logger.error(
+                "数据库锁被占用。请按顺序操作:\n"
+                "  1. 停止 backend/uvicorn 服务\n"
+                "  2. python migrations/diagnose_db_locks.py  查看阻塞 pid\n"
+                "  3. 必要时 SELECT pg_terminate_backend(<pid>);\n"
+                "  4. 重跑: python migrations/add_frontend_permissions.py\n"
+                "  或加大等待: set MIGRATION_LOCK_TIMEOUT_MS=600000 && python migrations/add_frontend_permissions.py"
+            )
+        raise SystemExit(1) from e

--- a/migrations/add_user_permissions.py
+++ b/migrations/add_user_permissions.py
@@ -1,0 +1,52 @@
+"""
+数据库迁移 - 用户级权限覆盖表 user_permissions
+同一角色下不同用户可有不同权限（grant 额外授予 / deny 相对角色撤销）
+"""
+
+import sys
+import os
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from sqlalchemy import create_engine, text
+from backend_api.config import DATABASE_CONFIG
+import logging
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+logger = logging.getLogger(__name__)
+
+LOCK_TIMEOUT_MS = int(os.environ.get("MIGRATION_LOCK_TIMEOUT_MS", "300000"))
+
+engine = create_engine(
+    DATABASE_CONFIG["url"],
+    pool_pre_ping=True,
+    pool_size=1,
+    max_overflow=0,
+    connect_args={
+        "connect_timeout": 15,
+        "options": f"-c lock_timeout={LOCK_TIMEOUT_MS} -c statement_timeout=600000",
+    },
+)
+
+
+def upgrade():
+    logger.info("创建 user_permissions 表...")
+    with engine.begin() as conn:
+        conn.execute(text("""
+            CREATE TABLE IF NOT EXISTS user_permissions (
+                user_id       INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                permission_id INT NOT NULL REFERENCES frontend_permissions(id) ON DELETE CASCADE,
+                granted       BOOLEAN NOT NULL,
+                created_at    TIMESTAMP DEFAULT NOW(),
+                PRIMARY KEY (user_id, permission_id)
+            )
+        """))
+        conn.execute(text("""
+            CREATE INDEX IF NOT EXISTS idx_user_permissions_user_id ON user_permissions(user_id)
+        """))
+    logger.info("✅ user_permissions 表迁移完成")
+
+
+if __name__ == "__main__":
+    upgrade()

--- a/migrations/diagnose_db_locks.py
+++ b/migrations/diagnose_db_locks.py
@@ -1,0 +1,91 @@
+"""
+诊断 PostgreSQL 锁等待（迁移前执行）
+
+用法:
+  python migrations/diagnose_db_locks.py
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from sqlalchemy import create_engine, text
+from backend_api.config import DATABASE_CONFIG
+
+engine = create_engine(
+    DATABASE_CONFIG["url"],
+    pool_pre_ping=True,
+    connect_args={"connect_timeout": 15},
+)
+
+QUERIES = [
+    ("当前连接", """
+        SELECT pid, usename, application_name, client_addr, state,
+               wait_event_type, wait_event,
+               now() - query_start AS query_age,
+               left(query, 120) AS query
+        FROM pg_stat_activity
+        WHERE datname = current_database()
+          AND pid <> pg_backend_pid()
+        ORDER BY query_start NULLS LAST
+    """),
+    ("阻塞关系", """
+        SELECT blocked.pid AS blocked_pid,
+               left(blocked.query, 80) AS blocked_query,
+               blocking.pid AS blocking_pid,
+               left(blocking.query, 80) AS blocking_query,
+               now() - blocking.query_start AS blocking_age
+        FROM pg_stat_activity blocked
+        JOIN pg_stat_activity blocking
+          ON blocking.pid = ANY(pg_catalog.pg_blocking_pids(blocked.pid))
+        WHERE blocked.datname = current_database()
+    """),
+    ("长事务 (>60s)", """
+        SELECT pid, state, usename, application_name,
+               now() - xact_start AS xact_age,
+               left(query, 100) AS query
+        FROM pg_stat_activity
+        WHERE datname = current_database()
+          AND xact_start IS NOT NULL
+          AND now() - xact_start > interval '60 seconds'
+          AND pid <> pg_backend_pid()
+        ORDER BY xact_start
+    """),
+    ("idle in transaction", """
+        SELECT pid, usename, application_name,
+               now() - state_change AS idle_age,
+               left(query, 100) AS last_query
+        FROM pg_stat_activity
+        WHERE datname = current_database()
+          AND state = 'idle in transaction'
+          AND pid <> pg_backend_pid()
+        ORDER BY state_change
+    """),
+]
+
+
+def main():
+    db_label = DATABASE_CONFIG["url"].split("@")[-1] if "@" in DATABASE_CONFIG["url"] else "?"
+    print(f"=== 数据库锁诊断: {db_label} ===\n")
+
+    with engine.connect() as conn:
+        for title, sql in QUERIES:
+            print(f"--- {title} ---")
+            rows = conn.execute(text(sql)).mappings().all()
+            if not rows:
+                print("  (无)\n")
+                continue
+            for row in rows:
+                print(" ", dict(row))
+            print()
+
+    print("建议:")
+    print("  1. 低峰期执行迁移，或先停止 backend / uvicorn 服务")
+    print("  2. 终止 idle in transaction 或长时间阻塞的 pid:")
+    print("     SELECT pg_terminate_backend(<blocking_pid>);")
+    print("  3. 再执行: python migrations/add_frontend_permissions.py")
+
+
+if __name__ == "__main__":
+    main()

--- a/migrations/sql/add_frontend_permissions.sql
+++ b/migrations/sql/add_frontend_permissions.sql
@@ -1,0 +1,66 @@
+-- 前端三级权限控制表（可 psql 手工执行）
+-- 用法: psql -h HOST -p PORT -U postgres -d stock_analysis -f migrations/sql/add_frontend_permissions.sql
+
+\set ON_ERROR_STOP on
+SET lock_timeout = '120s';
+SET statement_timeout = '600s';
+
+BEGIN;
+CREATE TABLE IF NOT EXISTS frontend_roles (
+    id          SERIAL PRIMARY KEY,
+    code        VARCHAR(50) UNIQUE NOT NULL,
+    name        VARCHAR(100) NOT NULL,
+    description TEXT,
+    is_system   BOOLEAN DEFAULT FALSE,
+    created_at  TIMESTAMP DEFAULT NOW()
+);
+COMMIT;
+
+BEGIN;
+CREATE TABLE IF NOT EXISTS frontend_permissions (
+    id           SERIAL PRIMARY KEY,
+    code         VARCHAR(200) UNIQUE NOT NULL,
+    name         VARCHAR(100) NOT NULL,
+    level        SMALLINT NOT NULL,
+    parent_code  VARCHAR(200),
+    channel_code VARCHAR(50),
+    sort_order   INT DEFAULT 0,
+    is_active    BOOLEAN DEFAULT TRUE,
+    created_at   TIMESTAMP DEFAULT NOW()
+);
+COMMIT;
+
+BEGIN;
+CREATE TABLE IF NOT EXISTS role_permissions (
+    role_id       INT NOT NULL REFERENCES frontend_roles(id) ON DELETE CASCADE,
+    permission_id INT NOT NULL REFERENCES frontend_permissions(id) ON DELETE CASCADE,
+    PRIMARY KEY (role_id, permission_id)
+);
+COMMIT;
+
+-- users.role_id：若应用占用 users 表，此步可能等待锁
+BEGIN;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS role_id INTEGER;
+CREATE INDEX IF NOT EXISTS idx_users_role_id ON users(role_id);
+COMMIT;
+
+BEGIN;
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'users_role_id_fkey') THEN
+        ALTER TABLE users ADD CONSTRAINT users_role_id_fkey
+            FOREIGN KEY (role_id) REFERENCES frontend_roles(id);
+    END IF;
+END $$;
+COMMIT;
+
+BEGIN;
+INSERT INTO frontend_roles (code, name, description, is_system) VALUES
+    ('standard', '标准用户', '默认角色，含全部已注册权限', TRUE),
+    ('admin', '前台管理员', '前台管理员，含全部权限', TRUE),
+    ('guest', '访客', '预留角色，本阶段不启用', TRUE)
+ON CONFLICT (code) DO NOTHING;
+COMMIT;
+
+-- 权限 seed 由 Python 脚本 migrations/add_frontend_permissions.py 同步（含完整列表）
+-- 部署后可在管理端「权限资源 -> 从注册表同步」完成

--- a/test/test_frontend_permissions.py
+++ b/test/test_frontend_permissions.py
@@ -1,0 +1,113 @@
+"""
+前端三级权限控制单元测试
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from backend_api.database import SessionLocal
+from backend_api.models import FrontendRole, User
+from backend_api.permissions import (
+    build_permissions_response,
+    get_role_permission_codes,
+    resolve_user_role,
+    user_has_permission,
+    build_permission_tree,
+)
+from backend_api.permission_registry_data import PERMISSION_REGISTRY
+
+
+def test_registry_not_empty():
+    assert len(PERMISSION_REGISTRY) >= 7
+    levels = {p["level"] for p in PERMISSION_REGISTRY}
+    assert levels == {1, 2, 3}
+
+
+def test_standard_role_has_permissions():
+    db = SessionLocal()
+    try:
+        role = db.query(FrontendRole).filter(FrontendRole.code == "standard").first()
+        assert role is not None
+        codes = get_role_permission_codes(db, role)
+        assert "channel.home" in codes
+        assert "channel.screening" in codes
+        assert len(codes) >= len(PERMISSION_REGISTRY)
+    finally:
+        db.close()
+
+
+def test_anonymous_gets_standard_permissions():
+    db = SessionLocal()
+    try:
+        resp = build_permissions_response(db, None)
+        assert resp.role.code == "standard"
+        assert "channel.home" in resp.permissions
+    finally:
+        db.close()
+
+
+def test_permission_tree_structure():
+    db = SessionLocal()
+    try:
+        tree = build_permission_tree(db)
+        assert len(tree) >= 7
+        screening = next((n for n in tree if n["code"] == "channel.screening"), None)
+        assert screening is not None
+        assert len(screening.get("children", [])) > 0
+    finally:
+        db.close()
+
+
+def test_user_role_resolution():
+    db = SessionLocal()
+    try:
+        user = db.query(User).first()
+        if not user:
+            return
+        role = resolve_user_role(db, user)
+        assert role is not None
+        assert user_has_permission(db, user, "channel.home") or not get_role_permission_codes(db, role)
+    finally:
+        db.close()
+
+
+def test_user_permission_override():
+    from backend_api.models import UserPermission, FrontendPermission
+    from backend_api.permissions import (
+        set_user_effective_permissions,
+        get_effective_permission_codes,
+        clear_user_permission_overrides,
+    )
+
+    db = SessionLocal()
+    try:
+        user = db.query(User).first()
+        if not user:
+            return
+        role_codes = set(get_effective_permission_codes(db, user))
+        if not role_codes:
+            return
+        # 撤销一项角色默认权限
+        target = "channel.screening" if "channel.screening" in role_codes else next(iter(role_codes))
+        new_effective = role_codes - {target}
+        set_user_effective_permissions(db, user, sorted(new_effective))
+        db.refresh(user)
+        effective = set(get_effective_permission_codes(db, user))
+        assert target not in effective
+        clear_user_permission_overrides(db, user.id)
+        db.refresh(user)
+        assert target in set(get_effective_permission_codes(db, user))
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    test_registry_not_empty()
+    test_standard_role_has_permissions()
+    test_anonymous_gets_standard_permissions()
+    test_permission_tree_structure()
+    test_user_role_resolution()
+    test_user_permission_override()
+    print("All permission tests passed.")


### PR DESCRIPTION
## Summary
- 新增前端频道/标签页/按钮三级权限体系，支持角色默认权限与用户级 grant/deny 覆盖合并
- 管理端新增角色管理、权限树配置、用户权限差异化配置界面
- 用户站集成权限引擎，无权限元素自动隐藏；关键写操作 API 增加后端鉴权

## Test plan
- [ ] 执行迁移：`python migrations/add_frontend_permissions.py` 与 `python migrations/add_user_permissions.py`
- [ ] 重启 backend，确认 `/docs` 存在 `GET /api/admin/users/{user_id}/permissions`
- [ ] 管理端：角色配置 → 用户管理 → 配置权限，保存后验证生效
- [ ] 用户站：不同角色/用户登录，验证频道、选股 Tab、按钮可见性
- [ ] 运行测试：`python test/test_frontend_permissions.py`